### PR TITLE
feat: validate duration parsing and document utilities

### DIFF
--- a/src/components/RangeComparisons.jsx
+++ b/src/components/RangeComparisons.jsx
@@ -1,6 +1,15 @@
 import React, { useMemo, useCallback } from 'react';
 import { parseDuration, mannWhitneyUTest } from '../utils/stats';
 
+/**
+ * Compare usage hours and AHI across two date ranges.
+ *
+ * @param {Object} props
+ * @param {Array<Object>} [props.summaryData] - Summary rows containing 'Total Time' and 'AHI' fields.
+ * @param {{ start: Date|null, end: Date|null }} [props.rangeA] - Range A.
+ * @param {{ start: Date|null, end: Date|null }} [props.rangeB] - Range B.
+ * @returns {JSX.Element|null}
+ */
 export default function RangeComparisons({ summaryData = [], rangeA, rangeB }) {
   const pick = useCallback(
     (r) => {

--- a/src/components/UsagePatternsCharts.jsx
+++ b/src/components/UsagePatternsCharts.jsx
@@ -13,6 +13,14 @@ import { useEffectiveDarkMode } from '../hooks/useEffectiveDarkMode';
 import { applyChartTheme } from '../utils/chartTheme';
 import VizHelp from './VizHelp';
 
+/**
+ * Render usage and adherence charts for nightly data.
+ *
+ * @param {Object} props
+ * @param {Array<Object>} props.data - Array of summary rows with 'Date' and 'Total Time'.
+ * @param {(range: {start: Date, end: Date})=>void} [props.onRangeSelect] - Callback when a range is selected.
+ * @returns {JSX.Element}
+ */
 export default function UsagePatternsCharts({ data, onRangeSelect }) {
   // Prepare sorted date and usage arrays
   const {

--- a/src/utils/stats.test.js
+++ b/src/utils/stats.test.js
@@ -26,6 +26,17 @@ describe('parseDuration', () => {
   it('handles MM:SS format', () => {
     expect(parseDuration('2:03')).toBe(123);
   });
+
+  it('returns NaN for malformed strings', () => {
+    expect(parseDuration('abc')).toBeNaN();
+    expect(parseDuration('1:2:3:4')).toBeNaN();
+  });
+
+  it('throws on malformed input when requested', () => {
+    expect(() => parseDuration('bad', { throwOnError: true })).toThrow(
+      /invalid duration/i
+    );
+  });
 });
 
 describe('kmSurvival (Kaplan–Meier) uncensored', () => {


### PR DESCRIPTION
## Summary
- validate duration parsing with error handling and NaN returns for malformed strings
- document utility methods and components with JSDoc
- test persistence and stats parsing for invalid duration scenarios

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf2383deec832f9c739ffeb851956b