### PR TITLE
ci: run lint in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
           node-version: '20'
       - name: Install dependencies
         run: npm ci
+      - name: Run lint
+        run: npm run lint
       - name: Check Vite warnings
         run: npm run build
       - name: Run tests with coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,13 +18,15 @@ This repo contains a Vite + React app for analyzing OSCAR sleep data, with tests
 - `npm run test:watch`: run tests in watch mode.
 - `npm run test:coverage`: run tests with coverage report.
 - `npm run prepare`: install Husky Git hooks.
+- `npm run lint`: run ESLint for code quality.
+- `npm run format`: apply Prettier formatting.
 
 ## Coding Style & Naming Conventions
 - Indentation: 2 spaces; semicolons optional but be consistent.
 - Components: `PascalCase` filenames (e.g., `UsagePatternsCharts.jsx`).
 - Functions/vars: `camelCase`; constants: `UPPER_SNAKE_CASE`.
 - Keep components functional and focused; co-locate tests and small helpers.
-- No linter is configured; ensure clean Vite builds with zero warnings.
+- ESLint and Prettier are configured; run `npm run lint` and `npm run format` to maintain code quality.
 
 ## Testing Guidelines
 - Frameworks: Vitest + @testing-library/react + jsdom.
@@ -34,8 +36,8 @@ This repo contains a Vite + React app for analyzing OSCAR sleep data, with tests
 
 ## Commit & Pull Request Guidelines
 - Style: prefer Conventional Commits (e.g., `feat:`, `fix:`, `chore:`) as in history.
-- Pre-commit: Husky runs `npm test` and `npm run build`; ensure both pass and builds have no warnings.
-- PRs: include clear description, linked issues, and screenshots/GIFs for UI changes. Ensure CI passes.
+- Pre-commit: Husky runs `npm run lint`, `npm test`, and `npm run build`; ensure all pass and builds have no warnings.
+- PRs: include clear description, linked issues, and screenshots/GIFs for UI changes. Ensure CI (lint, build, tests) passes.
 
 ## Security & Configuration Tips
 - Node: use version 20 (see CI). Avoid committing data exports containing sensitive information.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ npm run format
 
 The linter enforces strict rules such as React hook dependency completeness,
 no unused variables or empty blocks, and rejection of irregular whitespace.
-The pre-commit hook runs `npm run lint` along with tests and the build.
+The pre-commit hook runs `npm run lint` along with tests and the build, and CI also runs lint before building and testing.
 
 See `analysis.js` for usage details.
 


### PR DESCRIPTION
## Summary
- document that pre-commit runs lint alongside tests and build
- run `npm run lint` in the CI workflow before build and tests
- note in docs that CI linting runs before merging

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf257100c4832f9d1701f3059aea6b