### PR TITLE
refactor: extract false negative analysis and session hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Persistence & Sessions (opt-in)
 - Opt-in local persistence: Enable “Remember data locally” to save parsed Summary/Details, parameters, and ranges in IndexedDB; saving is debounced to avoid churn during frequent uploads and dev hot reloads.
 - Explicit controls: Save now, Load saved, Clear saved. Export/import full JSON sessions for sharing or backup.
 - Save now is enabled only after turning on “Remember data locally”. “Load saved” is always available and restores the last saved session if present.
+- The False Negatives view is implemented in a dedicated `FalseNegativesAnalysis` component, and session persistence is managed by a reusable `useSessionManager` hook.
 
 For contribution and workflow details, see [AGENTS.md](AGENTS.md).
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { useEffectiveDarkMode } from './hooks/useEffectiveDarkMode';
 import { useCsvFiles } from './hooks/useCsvFiles';
+import { useSessionManager } from './hooks/useSessionManager';
 import {
   clusterApneaEvents,
   detectFalseNegatives,
@@ -19,124 +19,16 @@ import SummaryAnalysis from './components/SummaryAnalysis';
 import ApneaClusterAnalysis from './components/ApneaClusterAnalysis';
 import ApneaEventStats from './components/ApneaEventStats';
 import RangeComparisons from './components/RangeComparisons';
-import Plot from 'react-plotly.js';
-import { applyChartTheme } from './utils/chartTheme';
+import FalseNegativesAnalysis from './components/FalseNegativesAnalysis';
 import RawDataExplorer from './components/RawDataExplorer';
 import ThemeToggle from './components/ThemeToggle';
 import DocsModal from './components/DocsModal';
 import GuideLink from './components/GuideLink';
-import VizHelp from './components/VizHelp';
-import { buildSession, applySession } from './utils/session';
-import { putLastSession, getLastSession, clearLastSession } from './utils/db';
 import {
   buildSummaryAggregatesCSV,
   downloadTextFile,
   openPrintReportHTML,
 } from './utils/export';
-
-function FalseNegativesAnalysis({ list, preset, onPresetChange }) {
-  const prefersDark = useEffectiveDarkMode();
-  return (
-    <div>
-      <h2 id="false-negatives">
-        Potential False Negatives{' '}
-        <GuideLink
-          anchor="potential-false-negatives-details-csv"
-          label="Guide"
-        />
-      </h2>
-      <div
-        style={{
-          display: 'flex',
-          gap: 12,
-          alignItems: 'center',
-          marginBottom: 8,
-        }}
-      >
-        <label>
-          Preset:
-          <select
-            value={preset}
-            onChange={(e) => onPresetChange?.(e.target.value)}
-          >
-            <option value="strict">Strict</option>
-            <option value="balanced">Balanced</option>
-            <option value="lenient">Lenient</option>
-          </select>
-        </label>
-        <span style={{ opacity: 0.8 }}>
-          Thresholds tuned for sensitivity/specificity
-        </span>
-      </div>
-      <div>
-        <h3>False Negative Clusters by Confidence Over Time</h3>
-        <div className="chart-with-help">
-          <Plot
-            key={prefersDark ? 'dark-fn' : 'light-fn'}
-            useResizeHandler
-            style={{ width: '100%', height: '400px' }}
-            data={[
-              {
-                type: 'scatter',
-                mode: 'markers',
-                x: list.map((cl) => cl.start),
-                y: list.map((cl) => cl.confidence * 100),
-                marker: {
-                  size: list.map((cl) =>
-                    Math.max(6, Math.min(20, Math.sqrt(cl.durationSec) * 5))
-                  ),
-                  color: list.map((cl) => cl.confidence * 100),
-                  colorscale: 'Viridis',
-                  showscale: true,
-                  colorbar: { title: 'Confidence (%)' },
-                },
-                text: list.map(
-                  (cl) =>
-                    `Start: ${cl.start.toLocaleString()}<br>Duration: ${cl.durationSec.toFixed(0)} s<br>Confidence: ${(cl.confidence * 100).toFixed(0)}%`
-                ),
-                hovertemplate: '%{text}<extra></extra>',
-              },
-            ]}
-            layout={applyChartTheme(prefersDark, {
-              title: 'False Negative Clusters by Confidence Over Time',
-              xaxis: { type: 'date', title: 'Cluster Start Time' },
-              yaxis: {
-                title: 'Confidence (%)',
-                range: [FALSE_NEG_CONFIDENCE_MIN * 100, 100],
-              },
-              margin: { l: 80, r: 20, t: 40, b: 40 },
-              height: 400,
-            })}
-            config={{ responsive: true, displaylogo: false }}
-          />
-          <VizHelp text="Each dot is a potential false-negative cluster. Position shows time and confidence; marker size scales with duration and color encodes confidence." />
-        </div>
-      </div>
-      <div className="cluster-table-container">
-        <table>
-          <thead>
-            <tr>
-              <th>#</th>
-              <th>Start</th>
-              <th>Duration (s)</th>
-              <th>Confidence</th>
-            </tr>
-          </thead>
-          <tbody>
-            {list.map((cl, i) => (
-              <tr key={i}>
-                <td>{i + 1}</td>
-                <td>{cl.start.toLocaleString()}</td>
-                <td>{cl.durationSec.toFixed(0)}</td>
-                <td>{(cl.confidence * 100).toFixed(0)}%</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
 
 function App() {
   const tocSections = useMemo(
@@ -211,6 +103,29 @@ function App() {
     };
     return presets[fnPreset] || presets.balanced;
   }, [fnPreset]);
+  const {
+    persistEnabled,
+    setPersistEnabled,
+    handleSaveNow,
+    handleLoadSaved,
+    handleClearSaved,
+    handleExportJson,
+    handleImportJson,
+  } = useSessionManager({
+    summaryData,
+    detailsData,
+    clusterParams,
+    dateFilter,
+    rangeA,
+    rangeB,
+    fnPreset,
+    setClusterParams,
+    setDateFilter,
+    setRangeA,
+    setRangeB,
+    setSummaryData,
+    setDetailsData,
+  });
 
   const onClusterParamChange = (patch) => {
     setClusterParams((prev) => ({ ...prev, ...patch }));
@@ -244,118 +159,6 @@ function App() {
     window.addEventListener('open-guide', handler);
     return () => window.removeEventListener('open-guide', handler);
   }, []);
-
-  // Session persistence (opt-in and explicit load/save to avoid conflicts with frequent uploads)
-  const [persistEnabled, setPersistEnabled] = useState(() => {
-    try {
-      return localStorage.getItem('persistEnabled') === '1';
-    } catch {
-      return false;
-    }
-  });
-  useEffect(() => {
-    try {
-      localStorage.setItem('persistEnabled', persistEnabled ? '1' : '0');
-    } catch {
-      // ignore persistence errors
-    }
-  }, [persistEnabled]);
-  useEffect(() => {
-    if (!persistEnabled) return;
-    const timer = setTimeout(() => {
-      const session = buildSession({
-        summaryData,
-        detailsData,
-        clusterParams,
-        dateFilter,
-        rangeA,
-        rangeB,
-        fnPreset,
-      });
-      putLastSession(session).catch(() => {});
-    }, 500);
-    return () => clearTimeout(timer);
-  }, [
-    persistEnabled,
-    summaryData,
-    detailsData,
-    clusterParams,
-    dateFilter,
-    rangeA,
-    rangeB,
-    fnPreset,
-  ]);
-  const handleSaveNow = async () => {
-    const session = buildSession({
-      summaryData,
-      detailsData,
-      clusterParams,
-      dateFilter,
-      rangeA,
-      rangeB,
-      fnPreset,
-    });
-    await putLastSession(session).catch(() => {});
-  };
-  const handleLoadSaved = async () => {
-    const sess = await getLastSession().catch(() => null);
-    if (sess) {
-      const patch = applySession(sess);
-      if (patch) {
-        setClusterParams(patch.clusterParams || clusterParams);
-        setDateFilter(patch.dateFilter || { start: null, end: null });
-        setRangeA(patch.rangeA || { start: null, end: null });
-        setRangeB(patch.rangeB || { start: null, end: null });
-        setSummaryData(patch.summaryData || null);
-        setDetailsData(patch.detailsData || null);
-      }
-    }
-  };
-  const handleClearSaved = async () => {
-    await clearLastSession().catch(() => {});
-  };
-  const handleExportJson = () => {
-    const session = buildSession({
-      summaryData,
-      detailsData,
-      clusterParams,
-      dateFilter,
-      rangeA,
-      rangeB,
-      fnPreset,
-    });
-    const blob = new Blob([JSON.stringify(session, null, 2)], {
-      type: 'application/json',
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'oscar_session.json';
-    a.click();
-    URL.revokeObjectURL(url);
-  };
-  const handleImportJson = (e) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => {
-      try {
-        const sess = JSON.parse(reader.result);
-        const patch = applySession(sess);
-        if (patch) {
-          setClusterParams(patch.clusterParams || clusterParams);
-          setDateFilter(patch.dateFilter || { start: null, end: null });
-          setRangeA(patch.rangeA || { start: null, end: null });
-          setRangeB(patch.rangeB || { start: null, end: null });
-          setSummaryData(patch.summaryData || null);
-          setDetailsData(patch.detailsData || null);
-        }
-      } catch {
-        // ignore invalid JSON
-      }
-    };
-    reader.readAsText(file);
-  };
 
   useEffect(() => {
     if (detailsData) {

--- a/src/components/FalseNegativesAnalysis.jsx
+++ b/src/components/FalseNegativesAnalysis.jsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import Plot from 'react-plotly.js';
+import { FALSE_NEG_CONFIDENCE_MIN } from '../utils/clustering';
+import { applyChartTheme } from '../utils/chartTheme';
+import { useEffectiveDarkMode } from '../hooks/useEffectiveDarkMode';
+import GuideLink from './GuideLink';
+import VizHelp from './VizHelp';
+
+function FalseNegativesAnalysis({ list, preset, onPresetChange }) {
+  const prefersDark = useEffectiveDarkMode();
+  return (
+    <div>
+      <h2 id="false-negatives">
+        Potential False Negatives{' '}
+        <GuideLink
+          anchor="potential-false-negatives-details-csv"
+          label="Guide"
+        />
+      </h2>
+      <div
+        style={{
+          display: 'flex',
+          gap: 12,
+          alignItems: 'center',
+          marginBottom: 8,
+        }}
+      >
+        <label>
+          Preset:
+          <select
+            value={preset}
+            onChange={(e) => onPresetChange?.(e.target.value)}
+          >
+            <option value="strict">Strict</option>
+            <option value="balanced">Balanced</option>
+            <option value="lenient">Lenient</option>
+          </select>
+        </label>
+        <span style={{ opacity: 0.8 }}>
+          Thresholds tuned for sensitivity/specificity
+        </span>
+      </div>
+      <div>
+        <h3>False Negative Clusters by Confidence Over Time</h3>
+        <div className="chart-with-help">
+          <Plot
+            key={prefersDark ? 'dark-fn' : 'light-fn'}
+            useResizeHandler
+            style={{ width: '100%', height: '400px' }}
+            data={[
+              {
+                type: 'scatter',
+                mode: 'markers',
+                x: list.map((cl) => cl.start),
+                y: list.map((cl) => cl.confidence * 100),
+                marker: {
+                  size: list.map((cl) =>
+                    Math.max(6, Math.min(20, Math.sqrt(cl.durationSec) * 5))
+                  ),
+                  color: list.map((cl) => cl.confidence * 100),
+                  colorscale: 'Viridis',
+                  showscale: true,
+                  colorbar: { title: 'Confidence (%)' },
+                },
+                text: list.map(
+                  (cl) =>
+                    `Start: ${cl.start.toLocaleString()}<br>Duration: ${cl.durationSec.toFixed(0)} s<br>Confidence: ${(cl.confidence * 100).toFixed(0)}%`
+                ),
+                hovertemplate: '%{text}<extra></extra>',
+              },
+            ]}
+            layout={applyChartTheme(prefersDark, {
+              title: 'False Negative Clusters by Confidence Over Time',
+              xaxis: { type: 'date', title: 'Cluster Start Time' },
+              yaxis: {
+                title: 'Confidence (%)',
+                range: [FALSE_NEG_CONFIDENCE_MIN * 100, 100],
+              },
+              margin: { l: 80, r: 20, t: 40, b: 40 },
+              height: 400,
+            })}
+            config={{ responsive: true, displaylogo: false }}
+          />
+          <VizHelp text="Each dot is a potential false-negative cluster. Position shows time and confidence; marker size scales with duration and color encodes confidence." />
+        </div>
+      </div>
+      <div className="cluster-table-container">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Start</th>
+              <th>Duration (s)</th>
+              <th>Confidence</th>
+            </tr>
+          </thead>
+          <tbody>
+            {list.map((cl, i) => (
+              <tr key={i}>
+                <td>{i + 1}</td>
+                <td>{cl.start.toLocaleString()}</td>
+                <td>{cl.durationSec.toFixed(0)}</td>
+                <td>{(cl.confidence * 100).toFixed(0)}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default FalseNegativesAnalysis;

--- a/src/components/FalseNegativesAnalysis.test.jsx
+++ b/src/components/FalseNegativesAnalysis.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FalseNegativesAnalysis from './FalseNegativesAnalysis';
+
+const sample = [
+  {
+    start: new Date('2024-01-01T00:00:00Z'),
+    durationSec: 60,
+    confidence: 0.9,
+  },
+];
+
+describe('FalseNegativesAnalysis', () => {
+  it('renders preset selector and calls change handler', () => {
+    const onChange = vi.fn();
+    render(
+      <FalseNegativesAnalysis
+        list={sample}
+        preset="balanced"
+        onPresetChange={onChange}
+      />
+    );
+    const select = screen.getByLabelText(/preset/i);
+    fireEvent.change(select, { target: { value: 'strict' } });
+    expect(onChange).toHaveBeenCalledWith('strict');
+    expect(screen.getByText(/false negative clusters/i)).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useSessionManager.js
+++ b/src/hooks/useSessionManager.js
@@ -1,0 +1,147 @@
+import { useState, useEffect } from 'react';
+import { buildSession, applySession } from '../utils/session';
+import { putLastSession, getLastSession, clearLastSession } from '../utils/db';
+
+export function useSessionManager({
+  summaryData,
+  detailsData,
+  clusterParams,
+  dateFilter,
+  rangeA,
+  rangeB,
+  fnPreset,
+  setClusterParams,
+  setDateFilter,
+  setRangeA,
+  setRangeB,
+  setSummaryData,
+  setDetailsData,
+}) {
+  const [persistEnabled, setPersistEnabled] = useState(() => {
+    try {
+      return localStorage.getItem('persistEnabled') === '1';
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('persistEnabled', persistEnabled ? '1' : '0');
+    } catch {
+      // ignore persistence errors
+    }
+  }, [persistEnabled]);
+
+  useEffect(() => {
+    if (!persistEnabled) return;
+    const timer = setTimeout(() => {
+      const session = buildSession({
+        summaryData,
+        detailsData,
+        clusterParams,
+        dateFilter,
+        rangeA,
+        rangeB,
+        fnPreset,
+      });
+      putLastSession(session).catch(() => {});
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [
+    persistEnabled,
+    summaryData,
+    detailsData,
+    clusterParams,
+    dateFilter,
+    rangeA,
+    rangeB,
+    fnPreset,
+  ]);
+
+  const handleSaveNow = async () => {
+    const session = buildSession({
+      summaryData,
+      detailsData,
+      clusterParams,
+      dateFilter,
+      rangeA,
+      rangeB,
+      fnPreset,
+    });
+    await putLastSession(session).catch(() => {});
+  };
+
+  const handleLoadSaved = async () => {
+    const sess = await getLastSession().catch(() => null);
+    if (sess) {
+      const patch = applySession(sess);
+      if (patch) {
+        setClusterParams(patch.clusterParams || clusterParams);
+        setDateFilter(patch.dateFilter || { start: null, end: null });
+        setRangeA(patch.rangeA || { start: null, end: null });
+        setRangeB(patch.rangeB || { start: null, end: null });
+        setSummaryData(patch.summaryData || null);
+        setDetailsData(patch.detailsData || null);
+      }
+    }
+  };
+
+  const handleClearSaved = async () => {
+    await clearLastSession().catch(() => {});
+  };
+
+  const handleExportJson = () => {
+    const session = buildSession({
+      summaryData,
+      detailsData,
+      clusterParams,
+      dateFilter,
+      rangeA,
+      rangeB,
+      fnPreset,
+    });
+    const blob = new Blob([JSON.stringify(session, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'oscar_session.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImportJson = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const sess = JSON.parse(reader.result);
+        const patch = applySession(sess);
+        if (patch) {
+          setClusterParams(patch.clusterParams || clusterParams);
+          setDateFilter(patch.dateFilter || { start: null, end: null });
+          setRangeA(patch.rangeA || { start: null, end: null });
+          setRangeB(patch.rangeB || { start: null, end: null });
+          setSummaryData(patch.summaryData || null);
+          setDetailsData(patch.detailsData || null);
+        }
+      } catch {
+        // ignore invalid JSON
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  return {
+    persistEnabled,
+    setPersistEnabled,
+    handleSaveNow,
+    handleLoadSaved,
+    handleClearSaved,
+    handleExportJson,
+    handleImportJson,
+  };
+}

--- a/src/hooks/useSessionManager.test.js
+++ b/src/hooks/useSessionManager.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSessionManager } from './useSessionManager';
+import { buildSession } from '../utils/session';
+
+const memoryStore = { last: null };
+
+vi.mock('../utils/db', () => ({
+  putLastSession: vi.fn(async (session) => {
+    memoryStore.last = session;
+  }),
+  getLastSession: vi.fn(async () => memoryStore.last),
+  clearLastSession: vi.fn(async () => {
+    memoryStore.last = null;
+  }),
+}));
+
+describe('useSessionManager', () => {
+  beforeEach(() => {
+    memoryStore.last = null;
+    try {
+      window.localStorage.removeItem('persistEnabled');
+    } catch {
+      // ignore
+    }
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('auto-saves when enabled', async () => {
+    const { result } = renderHook(() =>
+      useSessionManager({
+        summaryData: [],
+        detailsData: [],
+        clusterParams: {},
+        dateFilter: { start: null, end: null },
+        rangeA: { start: null, end: null },
+        rangeB: { start: null, end: null },
+        fnPreset: 'balanced',
+        setClusterParams: vi.fn(),
+        setDateFilter: vi.fn(),
+        setRangeA: vi.fn(),
+        setRangeB: vi.fn(),
+        setSummaryData: vi.fn(),
+        setDetailsData: vi.fn(),
+      })
+    );
+    act(() => result.current.setPersistEnabled(true));
+    vi.advanceTimersByTime(600);
+    const { putLastSession } = await import('../utils/db');
+    expect(putLastSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('loads a saved session', async () => {
+    memoryStore.last = buildSession({
+      summaryData: [{ AHI: '1' }],
+      detailsData: [],
+    });
+    const setSummaryData = vi.fn();
+    const { result } = renderHook(() =>
+      useSessionManager({
+        summaryData: [],
+        detailsData: [],
+        clusterParams: {},
+        dateFilter: { start: null, end: null },
+        rangeA: { start: null, end: null },
+        rangeB: { start: null, end: null },
+        fnPreset: 'balanced',
+        setClusterParams: vi.fn(),
+        setDateFilter: vi.fn(),
+        setRangeA: vi.fn(),
+        setRangeB: vi.fn(),
+        setSummaryData,
+        setDetailsData: vi.fn(),
+      })
+    );
+    await act(async () => {
+      await result.current.handleLoadSaved();
+    });
+    const { getLastSession } = await import('../utils/db');
+    expect(getLastSession).toHaveBeenCalledTimes(1);
+    expect(setSummaryData).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- extract `FalseNegativesAnalysis` into its own component
- add reusable `useSessionManager` hook for session persistence
- wire new component and hook into `App`
- cover new component and hook with unit tests and docs

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf7334fee0832fb73b8cd5da25f044