### PR TITLE
feat: add error boundary for charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ The Raw Data Explorer (see "Raw Data" in-page link) provides an efficient, virtu
 
 The app is built with Vite, React, and PapaParse. Environment variables for local configuration can be stored in a `.env` file at the project root, which is ignored by Git.
 
+### Error Handling
+
+Wrap chart-heavy sections in an `ErrorBoundary` to show a fallback UI if rendering fails:
+
+```jsx
+import ErrorBoundary from './components/ErrorBoundary';
+
+<ErrorBoundary fallback="Could not render chart">
+  <UsagePatternsCharts data={data} />
+</ErrorBoundary>;
+```
+
 Workers
 
 - Parsing: PapaParse runs in a web worker (`worker: true`).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import ApneaEventStats from './components/ApneaEventStats';
 import RangeComparisons from './components/RangeComparisons';
 import FalseNegativesAnalysis from './components/FalseNegativesAnalysis';
 import RawDataExplorer from './components/RawDataExplorer';
+import ErrorBoundary from './components/ErrorBoundary';
 import ThemeToggle from './components/ThemeToggle';
 import DocsModal from './components/DocsModal';
 import GuideLink from './components/GuideLink';
@@ -543,7 +544,9 @@ function App() {
       )}
       {filteredSummary && (
         <div className="section">
-          <SummaryAnalysis data={filteredSummary} clusters={apneaClusters} />
+          <ErrorBoundary>
+            <SummaryAnalysis data={filteredSummary} clusters={apneaClusters} />
+          </ErrorBoundary>
           <div style={{ marginTop: 8 }}>
             <h2 id="range-compare">
               Range Comparisons{' '}
@@ -621,42 +624,52 @@ function App() {
                 Use current filter as B
               </button>
             </div>
-            <RangeComparisons
-              summaryData={summaryData || []}
-              rangeA={rangeA}
-              rangeB={rangeB}
-            />
+            <ErrorBoundary>
+              <RangeComparisons
+                summaryData={summaryData || []}
+                rangeA={rangeA}
+                rangeB={rangeB}
+              />
+            </ErrorBoundary>
           </div>
         </div>
       )}
       {filteredDetails && (
         <>
           <div className="section">
-            <ApneaEventStats data={filteredDetails} />
+            <ErrorBoundary>
+              <ApneaEventStats data={filteredDetails} />
+            </ErrorBoundary>
           </div>
           <div className="section">
-            <ApneaClusterAnalysis
-              clusters={apneaClusters}
-              params={clusterParams}
-              onParamChange={onClusterParamChange}
-              details={filteredDetails}
-            />
+            <ErrorBoundary>
+              <ApneaClusterAnalysis
+                clusters={apneaClusters}
+                params={clusterParams}
+                onParamChange={onClusterParamChange}
+                details={filteredDetails}
+              />
+            </ErrorBoundary>
           </div>
           <div className="section">
-            <FalseNegativesAnalysis
-              list={falseNegatives}
-              preset={fnPreset}
-              onPresetChange={setFnPreset}
-            />
+            <ErrorBoundary>
+              <FalseNegativesAnalysis
+                list={falseNegatives}
+                preset={fnPreset}
+                onPresetChange={setFnPreset}
+              />
+            </ErrorBoundary>
           </div>
           <div className="section">
-            <RawDataExplorer
-              summaryRows={summaryData || []}
-              detailRows={detailsData || []}
-              onApplyDateFilter={({ start, end }) =>
-                setDateFilter({ start, end })
-              }
-            />
+            <ErrorBoundary>
+              <RawDataExplorer
+                summaryRows={summaryData || []}
+                detailRows={detailsData || []}
+                onApplyDateFilter={({ start, end }) =>
+                  setDateFilter({ start, end })
+                }
+              />
+            </ErrorBoundary>
           </div>
         </>
       )}

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert">{this.props.fallback || 'Something went wrong.'}</div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary.test.jsx
+++ b/src/components/ErrorBoundary.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import ErrorBoundary from './ErrorBoundary';
+
+function Bomb() {
+  throw new Error('boom');
+}
+
+function Okay() {
+  return <div>ok</div>;
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+
+  it('renders fallback when child throws', () => {
+    render(
+      <ErrorBoundary fallback="fallback text">
+        <Bomb />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('fallback text');
+  });
+
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary fallback="fallback text">
+        <Okay />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('ok')).toBeInTheDocument();
+  });
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import ErrorBoundary from './components/ErrorBoundary.jsx';
 
 import '../styles.css';
 import './guide.css';
@@ -9,6 +10,8 @@ const rootElement = document.getElementById('root');
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add reusable `ErrorBoundary` component
- wrap app and chart-heavy sections in `ErrorBoundary`
- document error boundary usage and add tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf8eef90e8832f88bfa73944d050dd