### PR TITLE
fix: use stable keys for mapped elements

### DIFF
--- a/src/components/AhiTrendsCharts.jsx
+++ b/src/components/AhiTrendsCharts.jsx
@@ -556,8 +556,8 @@ export default function AhiTrendsCharts({
               </tr>
             </thead>
             <tbody>
-              {badNights.slice(0, 10).map((b, i) => (
-                <tr key={i}>
+              {badNights.slice(0, 10).map((b) => (
+                <tr key={b.date.getTime()}>
                   <td>{b.date.toISOString().slice(0, 10)}</td>
                   <td>{b.ahi.toFixed(2)}</td>
                   <td>{b.reasons.join(', ')}</td>

--- a/src/components/ApneaClusterAnalysis.jsx
+++ b/src/components/ApneaClusterAnalysis.jsx
@@ -341,7 +341,7 @@ export default function ApneaClusterAnalysis({
           <tbody>
             {sorted.map((cl, i) => (
               <tr
-                key={i}
+                key={cl.start.getTime()}
                 onClick={() => setSelected(i)}
                 className={selected === i ? 'row-selected' : undefined}
                 style={{ cursor: 'pointer' }}

--- a/src/components/FalseNegativesAnalysis.jsx
+++ b/src/components/FalseNegativesAnalysis.jsx
@@ -96,7 +96,7 @@ function FalseNegativesAnalysis({ list, preset, onPresetChange }) {
           </thead>
           <tbody>
             {list.map((cl, i) => (
-              <tr key={i}>
+              <tr key={cl.start.getTime()}>
                 <td>{i + 1}</td>
                 <td>{cl.start.toLocaleString()}</td>
                 <td>{cl.durationSec.toFixed(0)}</td>

--- a/src/components/RawDataExplorer.jsx
+++ b/src/components/RawDataExplorer.jsx
@@ -343,7 +343,7 @@ export default function RawDataExplorer({
                   renderRow={(row, idx) => (
                     <div
                       role="row"
-                      key={idx}
+                      key={row.id ?? row.DateTime ?? row.Date ?? idx}
                       style={{
                         display: 'table',
                         tableLayout: 'fixed',
@@ -431,8 +431,8 @@ export default function RawDataExplorer({
               </tr>
             </thead>
             <tbody>
-              {pivot.rows.map((r, i) => (
-                <tr key={i}>
+              {pivot.rows.map((r) => (
+                <tr key={r[pivotBy]}>
                   {pivot.columns.map((c) => (
                     <td key={c}>
                       {typeof r[c] === 'number'


### PR DESCRIPTION
## Summary
- replace index-based keys in apnea, raw data, false-negative, and AHI components with stable identifiers
- ensure rendered collections rely on unique values like timestamps instead of array positions

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf97004f14832f98a97fb2d0ad531f