### PR TITLE
perf: memoize chart components

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ import ErrorBoundary from './components/ErrorBoundary';
 </ErrorBoundary>;
 ```
 
+### Performance
+
+`ApneaClusterAnalysis`, `EpapTrendsCharts`, and `UsagePatternsCharts` are wrapped in `React.memo` to skip unnecessary re-renders. When passing callbacks (e.g., `onParamChange`), wrap them with `useCallback` so their references remain stable.
+
 Workers
 
 - Parsing: PapaParse runs in a web worker (`worker: true`).

--- a/src/components/ApneaClusterAnalysis.jsx
+++ b/src/components/ApneaClusterAnalysis.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import Plot from 'react-plotly.js';
 import { useEffectiveDarkMode } from '../hooks/useEffectiveDarkMode';
 import { clustersToCsv } from '../utils/clustering';
@@ -6,12 +6,7 @@ import { applyChartTheme } from '../utils/chartTheme';
 import GuideLink from './GuideLink';
 import VizHelp from './VizHelp';
 
-export default function ApneaClusterAnalysis({
-  clusters,
-  params,
-  onParamChange,
-  details,
-}) {
+function ApneaClusterAnalysis({ clusters, params, onParamChange, details }) {
   const [selected, setSelected] = useState(null);
   const [sortBy, setSortBy] = useState({ key: 'severity', dir: 'desc' });
   const isDark = useEffectiveDarkMode();
@@ -44,7 +39,7 @@ export default function ApneaClusterAnalysis({
     return { leakTrace: leak, pressureTrace: pressure };
   }, [selectedCluster, details]);
 
-  const handleExport = () => {
+  const handleExport = useCallback(() => {
     const csv = clustersToCsv(clusters);
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
@@ -53,7 +48,7 @@ export default function ApneaClusterAnalysis({
     a.download = 'apnea_clusters.csv';
     a.click();
     URL.revokeObjectURL(url);
-  };
+  }, [clusters]);
 
   return (
     <div className="section">
@@ -359,3 +354,6 @@ export default function ApneaClusterAnalysis({
     </div>
   );
 }
+
+export { ApneaClusterAnalysis };
+export default React.memo(ApneaClusterAnalysis);

--- a/src/components/ApneaClusterAnalysis.test.jsx
+++ b/src/components/ApneaClusterAnalysis.test.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import ApneaClusterAnalysis from './ApneaClusterAnalysis.jsx';
+import * as ACA from './ApneaClusterAnalysis.jsx';
+
+const ApneaClusterAnalysis = ACA.default;
 
 describe('ApneaClusterAnalysis overlay', () => {
   it('shows leak/pressure chart when selecting a cluster', async () => {
@@ -54,5 +56,11 @@ describe('ApneaClusterAnalysis overlay', () => {
     expect(
       await screen.findByText(/Leak\/Pressure around Cluster/)
     ).toBeInTheDocument();
+  });
+});
+
+describe('ApneaClusterAnalysis memoization', () => {
+  it('exports a memoized component', () => {
+    expect(ApneaClusterAnalysis.type).toBe(ACA.ApneaClusterAnalysis);
   });
 });

--- a/src/components/EpapTrendsCharts.jsx
+++ b/src/components/EpapTrendsCharts.jsx
@@ -16,7 +16,7 @@ import {
  * time-series of EPAP with first/last 30-night markers,
  * and scatter plot of EPAP vs AHI with regression line and correlation coefficient.
  */
-export default function EpapTrendsCharts({ data }) {
+function EpapTrendsCharts({ data }) {
   const {
     dates,
     epaps,
@@ -662,3 +662,6 @@ export default function EpapTrendsCharts({ data }) {
     </div>
   );
 }
+
+export { EpapTrendsCharts };
+export default React.memo(EpapTrendsCharts);

--- a/src/components/EpapTrendsCharts.test.jsx
+++ b/src/components/EpapTrendsCharts.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import EpapTrendsCharts from './EpapTrendsCharts';
+import * as ETC from './EpapTrendsCharts';
+
+const EpapTrendsCharts = ETC.default;
 
 const data = [
   { Date: '2021-01-01', 'Median EPAP': '5', AHI: '1' },
@@ -13,5 +15,11 @@ describe('EpapTrendsCharts', () => {
     expect(getAllByTestId('plotly-chart').length).toBeGreaterThan(0);
     // 5 charts are always present for provided data
     expect(getAllByTestId('viz-help').length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe('EpapTrendsCharts memoization', () => {
+  it('exports a memoized component', () => {
+    expect(EpapTrendsCharts.type).toBe(ETC.EpapTrendsCharts);
   });
 });

--- a/src/components/UsagePatternsCharts.jsx
+++ b/src/components/UsagePatternsCharts.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import Plot from 'react-plotly.js';
 import {
   parseDuration,
@@ -21,7 +21,7 @@ import VizHelp from './VizHelp';
  * @param {(range: {start: Date, end: Date})=>void} [props.onRangeSelect] - Callback when a range is selected.
  * @returns {JSX.Element}
  */
-export default function UsagePatternsCharts({ data, onRangeSelect }) {
+function UsagePatternsCharts({ data, onRangeSelect }) {
   // Prepare sorted date and usage arrays
   const {
     dates,
@@ -125,6 +125,17 @@ export default function UsagePatternsCharts({ data, onRangeSelect }) {
 
   const isDark = useEffectiveDarkMode();
   const { longest_4, longest_6 } = computeAdherenceStreaks(usageHours, [4, 6]);
+
+  const handleRelayout = useCallback(
+    (ev) => {
+      const x0 = ev?.['xaxis.range[0]'];
+      const x1 = ev?.['xaxis.range[1]'];
+      if (x0 && x1 && onRangeSelect) {
+        onRangeSelect({ start: new Date(x0), end: new Date(x1) });
+      }
+    },
+    [onRangeSelect]
+  );
 
   return (
     <div className="usage-charts">
@@ -271,13 +282,7 @@ export default function UsagePatternsCharts({ data, onRangeSelect }) {
               })) || []),
             ],
           })}
-          onRelayout={(ev) => {
-            const x0 = ev?.['xaxis.range[0]'];
-            const x1 = ev?.['xaxis.range[1]'];
-            if (x0 && x1 && onRangeSelect) {
-              onRangeSelect({ start: new Date(x0), end: new Date(x1) });
-            }
-          }}
+          onRelayout={handleRelayout}
           config={{
             responsive: true,
             displaylogo: false,
@@ -436,3 +441,6 @@ export default function UsagePatternsCharts({ data, onRangeSelect }) {
     </div>
   );
 }
+
+export { UsagePatternsCharts };
+export default React.memo(UsagePatternsCharts);

--- a/src/components/UsagePatternsCharts.test.jsx
+++ b/src/components/UsagePatternsCharts.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import UsagePatternsCharts from './UsagePatternsCharts';
+import * as UPC from './UsagePatternsCharts';
+
+const UsagePatternsCharts = UPC.default;
 
 const data = [
   { Date: '2021-01-01', 'Total Time': '1:00:00' },
@@ -14,5 +16,11 @@ describe('UsagePatternsCharts', () => {
     expect(getAllByTestId('plotly-chart').length).toBeGreaterThan(0);
     // 4 charts => at least 4 help tooltips
     expect(getAllByTestId('viz-help').length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe('UsagePatternsCharts memoization', () => {
+  it('exports a memoized component', () => {
+    expect(UsagePatternsCharts.type).toBe(UPC.UsagePatternsCharts);
   });
 });


### PR DESCRIPTION
## Summary
- memoize ApneaClusterAnalysis, EpapTrendsCharts, and UsagePatternsCharts with `React.memo`
- stabilize callbacks with `useCallback` to reduce unnecessary renders
- document and test memoization behavior

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf9e2c4a2c832fb30ca53ef4b64382