### PR TITLE
ci: run lint, build, and tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,7 +19,29 @@ jobs:
         run: npm ci
       - name: Run lint
         run: npm run lint
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
       - name: Check Vite warnings
         run: npm run build
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
       - name: Run tests with coverage
         run: npm run test:coverage

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ npm run test:coverage
 Vite builds are also run in the pre-commit hook and CI to enforce clean builds without warnings; please resolve any Vite warnings before committing your code.
 Tests are automatically run before each commit via a Git hook configured with [Husky](https://typicode.github.io/husky/). After installing dependencies, run `npm run prepare` to set up Git hooks.
 
-Continuous integration is configured to run tests on GitHub Actions for each push and pull request (see `.github/workflows/ci.yml`).
+Continuous integration runs lint, build, and tests in parallel on GitHub Actions for each push and pull request (see `.github/workflows/ci.yml`).
 
 ### Linting and Formatting
 


### PR DESCRIPTION
## Summary
- split GitHub Actions workflow into separate lint, build, and test jobs so checks run concurrently
- document that CI now runs checks in parallel

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:coverage`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68bfa57ea608832f9891538020a7c008