### PR TITLE
test: cover CSV uploads and context behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,16 +152,16 @@ node analysis.js <detailsCsv> [YYYY-MM-DD] [groupGapSec]
 
 This project uses [Vitest](https://vitest.dev/) for unit and integration testing. Tests are colocated with source files using the `.test.*` suffix.
 
-**Run tests once:**
+**Run tests in watch mode:**
 
 ```bash
 npm run test
 ```
 
-**Run tests in watch mode:**
+**Run the full suite once (CI-style):**
 
 ```bash
-npm run test:watch
+npm test -- --run
 ```
 
 **Generate a coverage report:**

--- a/src/App.csv-upload.test.jsx
+++ b/src/App.csv-upload.test.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Papa from 'papaparse';
+import App from './App';
+
+// Tests cross-component behavior triggered by CSV uploads
+
+describe('CSV uploads and cross-component interactions', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows overview after summary upload and raw data explorer after details upload', async () => {
+    const parseMock = vi
+      .spyOn(Papa, 'parse')
+      .mockImplementation((file, options) => {
+        const isSummary = file.name.includes('summary');
+        const rows = isSummary
+          ? [
+              {
+                Date: '2025-06-01',
+                'Total Time': '08:00:00',
+                AHI: '5',
+                'Median EPAP': '6',
+              },
+            ]
+          : [
+              {
+                Event: 'ClearAirway',
+                DateTime: '2025-06-01T00:00:00',
+                'Data/Duration': '12',
+              },
+            ];
+        if (options.chunk) {
+          options.chunk({ data: rows, meta: { cursor: file.size } });
+        }
+        if (options.complete) {
+          options.complete({ data: rows });
+        }
+      });
+
+    render(<App />);
+
+    const summaryInput = screen.getByLabelText(/Summary CSV/i);
+    const summaryFile = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {
+      type: 'text/csv',
+    });
+    await userEvent.upload(summaryInput, summaryFile);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /Overview Dashboard/i })
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole('heading', { name: /Raw Data Explorer/i })
+    ).not.toBeInTheDocument();
+
+    const detailsInput = screen.getByLabelText(/Details CSV/i);
+    const detailsFile = new File(
+      ['Event,DateTime,Data/Duration\nClearAirway,2025-06-01T00:00:00,12'],
+      'details.csv',
+      { type: 'text/csv' }
+    );
+    await userEvent.upload(detailsInput, detailsFile);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /Raw Data Explorer/i })
+      ).toBeInTheDocument();
+    });
+
+    // Ensure Papa.parse ran for both files using workers
+    expect(parseMock).toHaveBeenCalledTimes(2);
+    expect(parseMock).toHaveBeenNthCalledWith(
+      1,
+      summaryFile,
+      expect.objectContaining({ worker: true })
+    );
+    expect(parseMock).toHaveBeenNthCalledWith(
+      2,
+      detailsFile,
+      expect.objectContaining({ worker: true })
+    );
+  });
+});

--- a/src/context/DataContext.test.jsx
+++ b/src/context/DataContext.test.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ErrorBoundary from '../components/ErrorBoundary';
+import { DataProvider, useData, THEMES } from './DataContext';
+
+describe('DataContext provider', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    document.documentElement.removeAttribute('data-theme');
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+
+  it('throws when useData is called outside provider', () => {
+    function Consumer() {
+      useData();
+      return null;
+    }
+    render(
+      <ErrorBoundary fallback="context error">
+        <Consumer />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('context error');
+  });
+
+  it('initializes theme from localStorage', () => {
+    window.localStorage.setItem('theme', THEMES.DARK);
+    render(
+      <DataProvider>
+        <div>child</div>
+      </DataProvider>
+    );
+    expect(document.documentElement.getAttribute('data-theme')).toBe(
+      THEMES.DARK
+    );
+  });
+
+  it('shares summary data updates across components', async () => {
+    function Setter() {
+      const { setSummaryData } = useData();
+      return (
+        <button
+          onClick={() => setSummaryData([{ Date: '2025-06-01', AHI: 5 }])}
+        >
+          load
+        </button>
+      );
+    }
+    function Display() {
+      const { summaryData } = useData();
+      return <div>{summaryData ? summaryData.length : 0}</div>;
+    }
+    const user = userEvent.setup();
+    function Wrapper() {
+      const [summary, setSummary] = React.useState(null);
+      return (
+        <DataProvider summaryData={summary} setSummaryData={setSummary}>
+          <Setter />
+          <Display />
+        </DataProvider>
+      );
+    }
+    render(<Wrapper />);
+    expect(screen.getByText('0')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /load/i }));
+    await screen.findByText('1');
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test for uploading Summary and Details CSVs and rendering linked sections
- exercise DataContext behavior including theme initialization and error handling
- document how to run the full test suite once

## Testing
- `npm run lint`
- `npm test -- --run --no-color`
- `npm run build` *(fails: process hung in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa77f3d84832fbb1d9336fd3a7da7