### PR TITLE
refactor: use shared clustering in CLI

### DIFF
--- a/analysis.js
+++ b/analysis.js
@@ -3,15 +3,35 @@
 //
 // Script to detect clusters of apnea events bridged by flow-limit (FLG) and
 // summarize relevant metrics within each cluster for a given date.
-// Usage: node analysis.js <detailsCsv> [YYYY-MM-DD] [groupGapSec]
+// Usage: node analysis.js <detailsCsv> [YYYY-MM-DD] [gapSec] [flgBridgeThreshold] [flgClusterGapSec]
 
 const fs = require('fs');
 const readline = require('readline');
 
-async function run(detailFilePath, targetDateStr, gapSec = 120, flgThreshold = 0.1, bridgeSec = 60) {
+async function run(detailFilePath, targetDateStr, opts = {}) {
+  const {
+    clusterApneaEvents,
+    APOEA_CLUSTER_MIN_TOTAL_SEC,
+    MAX_CLUSTER_DURATION_SEC,
+    APNEA_GAP_DEFAULT,
+    FLG_BRIDGE_THRESHOLD,
+    FLG_CLUSTER_GAP_DEFAULT,
+  } = await import('./src/utils/clustering.js');
+  const {
+    gapSec = APNEA_GAP_DEFAULT,
+    bridgeThreshold = FLG_BRIDGE_THRESHOLD,
+    bridgeSec = FLG_CLUSTER_GAP_DEFAULT,
+    edgeEnter,
+    edgeExit,
+    edgeMinDurSec,
+    minDensityPerMin,
+  } = opts;
   console.error(`Reading details from ${detailFilePath}`);
   const detailStream = fs.createReadStream(detailFilePath);
-  const rl = readline.createInterface({ input: detailStream, crlfDelay: Infinity });
+  const rl = readline.createInterface({
+    input: detailStream,
+    crlfDelay: Infinity,
+  });
   const summaryEvents = [];
   const flgEvents = [];
   const pressureEvents = [];
@@ -40,94 +60,38 @@ async function run(detailFilePath, targetDateStr, gapSec = 120, flgThreshold = 0
       epapEvents.push({ date: dt, level: val });
     }
   }
-  console.error(`Parsed ${summaryEvents.length} apnea summary events, ${flgEvents.length} FLG events`);
+  console.error(
+    `Parsed ${summaryEvents.length} apnea summary events, ${flgEvents.length} FLG events`
+  );
 
-  // Cluster apnea summary events with FLG bridging and stricter boundary extension
-  const EDGE_THRESHOLD = 0.5;        // FLG fraction threshold for true low-flow edge detection
-  const EDGE_MIN_DURATION_SEC = 10;   // min duration for FLG edge clusters (sec)
-  function clusterApneaEvents(events, flgEvents, gapSec, flgBridgeThreshold, bridgeSec) {
-    // cluster FLG events for bridging annotation gaps (low threshold)
-    const flgBridgeHigh = flgEvents.filter(f => f.level >= flgBridgeThreshold)
-      .sort((a, b) => a.date - b.date);
-    const flgBridgeClusters = [];
-    if (flgBridgeHigh.length) {
-      let vc = [flgBridgeHigh[0]];
-      for (let i = 1; i < flgBridgeHigh.length; i++) {
-        const prev = flgBridgeHigh[i - 1], curr = flgBridgeHigh[i];
-        if ((curr.date - prev.date) / 1000 <= bridgeSec) vc.push(curr);
-        else { flgBridgeClusters.push(vc); vc = [curr]; }
-      }
-      flgBridgeClusters.push(vc);
-    }
-    // cluster FLG events for boundary extension (higher threshold, min duration)
-    const flgEdgeHigh = flgEvents.filter(f => f.level >= EDGE_THRESHOLD)
-      .sort((a, b) => a.date - b.date);
-    const flgEdgeClusters = [];
-    if (flgEdgeHigh.length) {
-      let vc = [flgEdgeHigh[0]];
-      for (let i = 1; i < flgEdgeHigh.length; i++) {
-        const prev = flgEdgeHigh[i - 1], curr = flgEdgeHigh[i];
-        if ((curr.date - prev.date) / 1000 <= bridgeSec) vc.push(curr);
-        else { flgEdgeClusters.push(vc); vc = [curr]; }
-      }
-      flgEdgeClusters.push(vc);
-    }
-    // group annotation events by proximity and FLG bridges
-    const sorted = events.slice().sort((a, b) => a.date - b.date);
-    const rawGroups = [];
-    let current = [sorted[0]];
-    for (let i = 1; i < sorted.length; i++) {
-      const evt = sorted[i];
-      const prev = current[current.length - 1];
-      const prevEnd = new Date(prev.date.getTime() + prev.durationSec * 1000);
-      const gap = (evt.date - prevEnd) / 1000;
-      const flgBridge = gap <= bridgeSec && flgBridgeHigh.some(f => f.date >= prevEnd && f.date <= evt.date);
-      if (gap <= gapSec || flgBridge) {
-        current.push(evt);
-      } else {
-        rawGroups.push(current);
-        current = [evt];
-      }
-    }
-    if (current.length) rawGroups.push(current);
-    // map to clusters and extend boundaries using filtered FLG edge clusters
-    return rawGroups.map(group => {
-      let start = group[0].date;
-      const lastEvt = group[group.length - 1];
-      let end = new Date(lastEvt.date.getTime() + lastEvt.durationSec * 1000);
-      const count = group.length;
-      const validEdges = flgEdgeClusters.filter(cl =>
-        (cl[cl.length - 1].date - cl[0].date) / 1000 >= EDGE_MIN_DURATION_SEC
-      );
-      const before = validEdges.find(cl =>
-        cl[cl.length - 1].date <= start && (start - cl[cl.length - 1].date) / 1000 <= gapSec
-      );
-      if (before) start = before[0].date;
-      const after = validEdges.find(cl =>
-        cl[0].date >= end && (cl[0].date - end) / 1000 <= gapSec
-      );
-      if (after) end = after[after.length - 1].date;
-      return { start, end, durationSec: (end - start) / 1000, count, events: group };
-    });
-  }
-
-  const clusters = summaryEvents.length > 0
-    ? clusterApneaEvents(summaryEvents, flgEvents, gapSec, flgThreshold, bridgeSec)
-    : [];
-  const minTotalEventDurSec = 60;
-  const maxClusterDurationSec = 230; // sanity cap on cluster window (sec)
-  const valid = clusters.filter(c => {
+  const clusters =
+    summaryEvents.length > 0
+      ? clusterApneaEvents(
+          summaryEvents,
+          flgEvents,
+          gapSec,
+          bridgeThreshold,
+          bridgeSec,
+          edgeEnter,
+          edgeExit,
+          edgeMinDurSec,
+          minDensityPerMin
+        )
+      : [];
+  const valid = clusters.filter((c) => {
     const totalEventDur = c.events.reduce((sum, e) => sum + e.durationSec, 0);
-    return c.count >= 3 &&
-           totalEventDur >= minTotalEventDurSec &&
-           c.durationSec <= maxClusterDurationSec;
+    return (
+      c.count >= 3 &&
+      totalEventDur >= APOEA_CLUSTER_MIN_TOTAL_SEC &&
+      c.durationSec <= MAX_CLUSTER_DURATION_SEC
+    );
   });
   if (!valid.length) {
     console.log(
-      `No apnea clusters (≥3 events and ≥${minTotalEventDurSec}s total) found for`,
+      `No apnea clusters (≥3 events and ≥${APOEA_CLUSTER_MIN_TOTAL_SEC}s total) found for`,
       targetDateStr
     );
-    return;
+    return [];
   }
   console.log(`Detected apnea clusters for ${targetDateStr}:`);
   valid.forEach((c, i) => {
@@ -136,22 +100,52 @@ async function run(detailFilePath, targetDateStr, gapSec = 120, flgThreshold = 0
     console.log(`  End:      ${c.end.toISOString()}`);
     console.log(`  Duration: ${c.durationSec.toFixed(1)} sec`);
     console.log(`  Events:`);
-    c.events.forEach(e => console.log(`    ${e.type} @ ${e.date.toISOString()} dur=${e.durationSec}s`));
-    const flgIn = flgEvents.filter(f => f.date >= c.start && f.date <= c.end).map(f => f.level);
-    if (flgIn.length) console.log(`  FLG levels: min=${Math.min(...flgIn)}, max=${Math.max(...flgIn)} (${flgIn.length} samples)`);
-    const pIn = pressureEvents.filter(p => p.date >= c.start && p.date <= c.end).map(p => p.level);
-    if (pIn.length) console.log(`  Pressure:   min=${Math.min(...pIn)}, max=${Math.max(...pIn)}`);
-    const eIn = epapEvents.filter(p => p.date >= c.start && p.date <= c.end).map(p => p.level);
-    if (eIn.length) console.log(`  EPAP:       min=${Math.min(...eIn)}, max=${Math.max(...eIn)}`);
+    c.events.forEach((e) =>
+      console.log(
+        `    ${e.type} @ ${e.date.toISOString()} dur=${e.durationSec}s`
+      )
+    );
+    const flgIn = flgEvents
+      .filter((f) => f.date >= c.start && f.date <= c.end)
+      .map((f) => f.level);
+    if (flgIn.length)
+      console.log(
+        `  FLG levels: min=${Math.min(...flgIn)}, max=${Math.max(...flgIn)} (${flgIn.length} samples)`
+      );
+    const pIn = pressureEvents
+      .filter((p) => p.date >= c.start && p.date <= c.end)
+      .map((p) => p.level);
+    if (pIn.length)
+      console.log(
+        `  Pressure:   min=${Math.min(...pIn)}, max=${Math.max(...pIn)}`
+      );
+    const eIn = epapEvents
+      .filter((p) => p.date >= c.start && p.date <= c.end)
+      .map((p) => p.level);
+    if (eIn.length)
+      console.log(
+        `  EPAP:       min=${Math.min(...eIn)}, max=${Math.max(...eIn)}`
+      );
   });
+  return valid;
 }
+
+module.exports = { run };
 
 // Entry point
 const args = process.argv.slice(2);
 if (args.length < 1) {
-  console.error('Usage: node analysis.js <detailsCsv> [YYYY-MM-DD] [groupGapSec]');
+  console.error(
+    'Usage: node analysis.js <detailsCsv> [YYYY-MM-DD] [gapSec] [flgBridgeThreshold] [flgClusterGapSec]'
+  );
   process.exit(1);
 }
-const [detailsCsv, dateStr, gapArg] = args;
-const gap = gapArg ? parseInt(gapArg, 10) : 120;
-run(detailsCsv, dateStr || '2025-06-15', gap).catch(err => { console.error(err); process.exit(1); });
+const [detailsCsv, dateStr, gapArg, flgArg, bridgeArg] = args;
+const cliOpts = {};
+if (gapArg) cliOpts.gapSec = parseInt(gapArg, 10);
+if (flgArg) cliOpts.bridgeThreshold = parseFloat(flgArg);
+if (bridgeArg) cliOpts.bridgeSec = parseInt(bridgeArg, 10);
+run(detailsCsv, dateStr || '2025-06-15', cliOpts).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/analysis.test.js
+++ b/analysis.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import analysis from './analysis.js';
+import {
+  clusterApneaEvents,
+  APOEA_CLUSTER_MIN_TOTAL_SEC,
+  MAX_CLUSTER_DURATION_SEC,
+} from './src/utils/clustering.js';
+
+const { run } = analysis;
+
+describe('analysis CLI clustering', () => {
+  it('matches clustering from shared utility', async () => {
+    const csv = [
+      'DateTime,Type,Event,Data/Duration',
+      '2021-01-01T00:00:00,0,ClearAirway,20',
+      '2021-01-01T00:01:00,0,Obstructive,20',
+      '2021-01-01T00:02:00,0,Mixed,30',
+      '2021-01-01T00:01:30,0,FLG,0.2',
+    ].join('\n');
+    const tmp = path.join(process.cwd(), 'tmp-details.csv');
+    fs.writeFileSync(tmp, csv);
+
+    const cliClusters = await run(tmp, '2021-01-01');
+
+    const events = [
+      {
+        date: new Date('2021-01-01T00:00:00Z'),
+        type: 'ClearAirway',
+        durationSec: 20,
+      },
+      {
+        date: new Date('2021-01-01T00:01:00Z'),
+        type: 'Obstructive',
+        durationSec: 20,
+      },
+      {
+        date: new Date('2021-01-01T00:02:00Z'),
+        type: 'Mixed',
+        durationSec: 30,
+      },
+    ];
+    const flgEvents = [{ date: new Date('2021-01-01T00:01:30Z'), level: 0.2 }];
+    const clusters = clusterApneaEvents(events, flgEvents);
+    const expected = clusters.filter((c) => {
+      const totalEventDur = c.events.reduce((sum, e) => sum + e.durationSec, 0);
+      return (
+        c.count >= 3 &&
+        totalEventDur >= APOEA_CLUSTER_MIN_TOTAL_SEC &&
+        c.durationSec <= MAX_CLUSTER_DURATION_SEC
+      );
+    });
+
+    expect(cliClusters).toEqual(expected);
+    fs.unlinkSync(tmp);
+  });
+});

--- a/docs/user/05-faq.md
+++ b/docs/user/05-faq.md
@@ -1,56 +1,71 @@
 # Frequently Asked Questions
 
-This section answers common questions about the OSCAR Export Analyzer.  If you encounter an issue not covered here, please open an issue on the project repository.
+This section answers common questions about the OSCAR Export Analyzer. If you encounter an issue not covered here, please open an issue on the project repository.
 
 ## General
 
 ### Can I analyze nights without a Details CSV?
-Yes.  Most views only require the Summary CSV.  Event‑level analyses such as cluster detection and false negatives become available when a Details file is loaded.
+
+Yes. Most views only require the Summary CSV. Event‑level analyses such as cluster detection and false negatives become available when a Details file is loaded.
 
 ### Why does a CSV fail to parse?
-Ensure the file is exported from OSCAR and uses UTF‑8 encoding.  Files edited in spreadsheet software may introduce stray headers or change the delimiter.  If parsing stalls, open the browser console for error messages and verify that column names match those in the [data dictionary](03-data-dictionary.md).
+
+Ensure the file is exported from OSCAR and uses UTF‑8 encoding. Files edited in spreadsheet software may introduce stray headers or change the delimiter. If parsing stalls, open the browser console for error messages and verify that column names match those in the [data dictionary](03-data-dictionary.md).
 
 ### How is data stored?
-When **Remember data locally** is enabled, files and settings are saved to IndexedDB.  Disabling the option removes stored copies.  You can also manually clear all cached data via the session controls.
+
+When **Remember data locally** is enabled, files and settings are saved to IndexedDB. Disabling the option removes stored copies. You can also manually clear all cached data via the session controls.
 
 ### Can I export results for my doctor?
-Use the print‑friendly PDF report or the aggregates CSV for sharing.  The report contains key charts, while the aggregates file lists nightly usage, AHI, EPAP, and cluster metrics.
+
+Use the print‑friendly PDF report or the aggregates CSV for sharing. The report contains key charts, while the aggregates file lists nightly usage, AHI, EPAP, and cluster metrics.
 
 ### Is my data uploaded anywhere?
-No.  All processing happens within your browser.  The only network requests performed are for application assets such as JavaScript bundles.
+
+No. All processing happens within your browser. The only network requests performed are for application assets such as JavaScript bundles.
 
 ## Visualization
 
 ### How are rolling averages computed?
-Rolling windows include calendar days even when no data exists, preventing inflated averages after gaps.  See [Statistical Concepts](04-statistical-concepts.md) for formulas.
+
+Rolling windows include calendar days even when no data exists, preventing inflated averages after gaps. See [Statistical Concepts](04-statistical-concepts.md) for formulas.
 
 ### What do the colors in the calendar heatmap mean?
-The heatmap uses a gradient from light (low usage) to dark (high usage).  You can hover any cell to see the exact hours used on that date.
+
+The heatmap uses a gradient from light (low usage) to dark (high usage). You can hover any cell to see the exact hours used on that date.
 
 ### Why are some charts empty?
-Certain visualizations require specific columns.  For example, the correlation matrix appears only if leak data is present.  Verify that your Summary CSV contains the necessary fields.
+
+Certain visualizations require specific columns. For example, the correlation matrix appears only if leak data is present. Verify that your Summary CSV contains the necessary fields.
 
 ## Troubleshooting
 
 ### The page freezes when I load a large CSV.
-Parsing occurs in a Web Worker and should remain responsive, but extremely large exports may still strain memory.  Try limiting the export to a smaller date range or using a browser with more available RAM.
+
+Parsing occurs in a Web Worker and should remain responsive, but extremely large exports may still strain memory. Try limiting the export to a smaller date range or using a browser with more available RAM.
 
 ### The session does not save between visits.
-Ensure **Remember data locally** is enabled.  Some privacy modes or browser settings (e.g., “Clear cookies on exit”) prevent IndexedDB persistence.
+
+Ensure **Remember data locally** is enabled. Some privacy modes or browser settings (e.g., “Clear cookies on exit”) prevent IndexedDB persistence.
 
 ### I accidentally imported the wrong file. How do I reset?
+
 Click **Clear saved** in the session controls or refresh the page with local storage disabled.
 
 ### Can I run the analyzer offline?
-Yes.  Once the application is loaded, it functions without an internet connection.  You can even package it as a static site and open `index.html` directly in a browser.
+
+Yes. Once the application is loaded, it functions without an internet connection. You can even package it as a static site and open `index.html` directly in a browser.
 
 ## Advanced
 
 ### How can I customize clustering thresholds?
-Open the “Clustered Apnea Events” panel and expand the settings section.  You can adjust gap thresholds, FLG bridging, minimum density, and other parameters.  Settings persist with the session.
+
+Open the “Clustered Apnea Events” panel and expand the settings section. You can adjust gap thresholds, FLG bridging, minimum density, and other parameters. Settings persist with the session.
 
 ### Can I script analyses instead of using the UI?
-The repository includes `analysis.js`, a Node script that can load the same CSV files and output derived metrics.  Run `node analysis.js --help` for usage.
+
+The repository includes `analysis.js`, a Node script that mirrors the app's clustering logic. Run `node analysis.js <Details.csv> [YYYY-MM-DD] [gapSec] [flgBridgeThreshold] [flgClusterGapSec]` to analyze a night from the command line.
 
 ### Does the analyzer support non‑OSCAR CSVs?
-Not directly.  However, you can transform other data sources into the expected format described in the [data dictionary](03-data-dictionary.md).  Future versions may include import adapters.
+
+Not directly. However, you can transform other data sources into the expected format described in the [data dictionary](03-data-dictionary.md). Future versions may include import adapters.

--- a/docs/user/06-troubleshooting.md
+++ b/docs/user/06-troubleshooting.md
@@ -1,57 +1,67 @@
 # Troubleshooting Guide
 
-This chapter lists common issues and step‑by‑step solutions.  Always ensure you are running the latest version of the analyzer before reporting a bug.
+This chapter lists common issues and step‑by‑step solutions. Always ensure you are running the latest version of the analyzer before reporting a bug.
 
 ## File Loading Problems
 
 ### "File type not supported" message
+
 - Confirm the file extension is `.csv`.
 - Ensure the export came directly from OSCAR without being opened in Excel or another editor that might alter formatting.
 - Check that the first row contains a header row with fields like `Date` or `Event`.
 
 ### Progress bar freezes midway
+
 - Very large files may take several minutes; keep the tab active.
-- Inspect the browser console for parse errors.  Rows with malformed timestamps or non‑numeric values are skipped but counted.
+- Inspect the browser console for parse errors. Rows with malformed timestamps or non‑numeric values are skipped but counted.
 - If memory usage spikes, try trimming the export to fewer nights.
 
 ### Charts show no data
+
 - Verify that the Summary CSV was successfully parsed (look for console messages indicating row counts).
-- Ensure `Date` values use `YYYY-MM-DD`.  Other formats may be interpreted as invalid dates.
+- Ensure `Date` values use `YYYY-MM-DD`. Other formats may be interpreted as invalid dates.
 - For details‑dependent charts (clusters, false negatives), confirm the Details CSV was loaded and contains `Event` and `DateTime` columns.
 
 ## Performance and Display
 
 ### Sluggish interface when zooming
+
 - Disable other intensive applications to free system resources.
 - Try a Chromium‑based browser, which offers faster canvas rendering than some alternatives.
 - Reduce the number of nights loaded by filtering the CSV before import.
 
 ### Charts do not render or appear blank
+
 - Clear the session via **Clear saved** and reload the page.
 - Disable browser extensions that inject content scripts, as they can interfere with canvas rendering.
 - Verify that WebGL is enabled in your browser; some visualizations fall back to CPU rendering otherwise.
 
 ### Wrong time zone displayed
-- OSCAR exports use the local time of the machine that created them.  If your computer’s time zone changed, times may appear shifted.  Re‑export the data from OSCAR using the correct time zone to fix historical records.
+
+- OSCAR exports use the local time of the machine that created them. If your computer’s time zone changed, times may appear shifted. Re‑export the data from OSCAR using the correct time zone to fix historical records.
 
 ## Session Persistence
 
 ### Saved sessions disappear after closing the browser
-- Some privacy settings clear `IndexedDB` on exit.  Check your browser’s cookie and site‑data retention policies.
+
+- Some privacy settings clear `IndexedDB` on exit. Check your browser’s cookie and site‑data retention policies.
 - In private/incognito mode, enable **Export JSON** to manually save a session between visits.
 
 ### Unable to import a previously exported JSON
-- Ensure the file was exported from the same or a newer version of the analyzer.  Older snapshots may use outdated field names.
-- Verify that the file was not modified.  JSON must be valid and UTF‑8 encoded.
+
+- Ensure the file was exported from the same or a newer version of the analyzer. Older snapshots may use outdated field names.
+- Verify that the file was not modified. JSON must be valid and UTF‑8 encoded.
 
 ## Miscellaneous
 
 ### Printed report misses charts
-- The browser’s print dialog may omit background graphics.  Enable “Print backgrounds” or “Background graphics” in print settings.
+
+- The browser’s print dialog may omit background graphics. Enable “Print backgrounds” or “Background graphics” in print settings.
 - Use landscape orientation for wide charts such as correlation matrices.
 
 ### Analysis.js fails with "Cannot find module"
+
 - Run `npm install` to ensure dependencies are available.
-- Execute the script with Node 20: `node analysis.js path/to/Summary.csv`.
+- Execute the script with Node 20: `node analysis.js path/to/Details.csv [YYYY-MM-DD]`.
 
 If these steps do not resolve your problem, consult the project’s issue tracker and include console logs, browser version, and a description of the steps leading to the error.


### PR DESCRIPTION
## Summary
- reuse `clusterApneaEvents` from shared utils in `analysis.js`
- pass gap and flow-limit options through CLI
- document new CLI usage and add regression test

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c02c3929cc832fadae9a053f3e2856