### PR TITLE
feat: add themed plot wrapper

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -3,5 +3,6 @@
 The app is a Vite + React single page application.
 
 - **Component Hierarchy**: `App` hosts file pickers and analysis sections. Visualization components live in `src/components` and are wrapped with `ErrorBoundary` as needed.
+- **Component Hierarchy**: `App` hosts file pickers and analysis sections. Visualization components live in `src/components` and are wrapped with `ErrorBoundary` as needed. Charts should use `ThemedPlot` to automatically apply light or dark styling.
 - **State Management**: `DataContext` provides parsed CSV data, parameters, and theme. Hooks such as `useData` and `useTheme` access and update this state.
 - **Data Flow**: Uploaded CSVs are parsed with PapaParse in a worker. Results are stored in context and passed to chart components. Additional workers handle cluster and false-negative analysis.

--- a/src/components/AhiTrendsCharts.jsx
+++ b/src/components/AhiTrendsCharts.jsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-import Plot from 'react-plotly.js';
 import {
   quantile,
   detectUsageBreakpoints,
@@ -7,8 +6,7 @@ import {
   detectChangePoints,
 } from '../utils/stats';
 import { COLORS } from '../utils/colors';
-import { useEffectiveDarkMode } from '../hooks/useEffectiveDarkMode';
-import { applyChartTheme } from '../utils/chartTheme';
+import ThemedPlot from './ThemedPlot';
 import VizHelp from './VizHelp';
 
 export default function AhiTrendsCharts({
@@ -98,8 +96,6 @@ export default function AhiTrendsCharts({
   const range = Math.max(...ahis) - Math.min(...ahis);
   const nbins = binWidth > 0 ? Math.ceil(range / binWidth) : 12;
 
-  const isDark = useEffectiveDarkMode();
-
   // Severity bands counts
   const bands = {
     le5: ahis.filter((v) => v <= 5).length,
@@ -182,8 +178,7 @@ export default function AhiTrendsCharts({
   return (
     <div className="usage-charts">
       <div className="chart-with-help">
-        <Plot
-          key={isDark ? 'dark' : 'light'}
+        <ThemedPlot
           useResizeHandler
           style={{ width: '100%', height: '300px' }}
           data={[
@@ -292,7 +287,7 @@ export default function AhiTrendsCharts({
                 ]
               : []),
           ]}
-          layout={applyChartTheme(isDark, {
+          layout={{
             title: 'Nightly AHI Over Time',
             legend: { orientation: 'h', x: 0.5, xanchor: 'center' },
             shapes: [
@@ -338,7 +333,7 @@ export default function AhiTrendsCharts({
             xaxis: { title: 'Date' },
             yaxis: { title: 'AHI (events/hour)' },
             margin: { t: 40, l: 60, r: 20, b: 50 },
-          })}
+          }}
           onRelayout={(ev) => {
             const x0 = ev?.['xaxis.range[0]'];
             const x1 = ev?.['xaxis.range[1]'];
@@ -358,8 +353,7 @@ export default function AhiTrendsCharts({
 
       <div className="usage-charts-grid">
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-hist' : 'light-hist'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -371,7 +365,7 @@ export default function AhiTrendsCharts({
                 marker: { color: COLORS.primary },
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'Distribution of Nightly AHI',
               legend: { orientation: 'h', x: 0.5, xanchor: 'center' },
               shapes: [
@@ -415,7 +409,7 @@ export default function AhiTrendsCharts({
               xaxis: { title: 'AHI (events/hour)' },
               yaxis: { title: 'Count' },
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
             config={{
               responsive: true,
               displaylogo: false,
@@ -429,8 +423,7 @@ export default function AhiTrendsCharts({
           <VizHelp text="Distribution of nightly AHI values. Dashed line marks the median; dotted line marks the mean." />
         </div>
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-box' : 'light-box'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -442,19 +435,18 @@ export default function AhiTrendsCharts({
                 marker: { color: '#888' },
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'Boxplot of Nightly AHI',
               yaxis: { title: 'AHI (events/hour)', zeroline: false },
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
           />
           <VizHelp text="Boxplot of nightly AHI; box shows the interquartile range (IQR) and points indicate outliers." />
         </div>
       </div>
       <div className="usage-charts-grid">
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-violin' : 'light-violin'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -466,17 +458,16 @@ export default function AhiTrendsCharts({
                 box: { visible: true },
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'Violin Plot of Nightly AHI',
               yaxis: { title: 'AHI (events/hour)' },
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
           />
           <VizHelp text="Violin plot of nightly AHI; width shows density of values. Inner box shows quartiles and median." />
         </div>
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-qq' : 'light-qq'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -497,12 +488,12 @@ export default function AhiTrendsCharts({
                 line: { dash: 'dash' },
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'QQ Plot vs Normal',
               xaxis: { title: 'Theoretical Quantiles' },
               yaxis: { title: 'Observed AHI Quantiles' },
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
           />
           <VizHelp text="QQ plot comparing observed AHI quantiles to a theoretical normal distribution. Deviations from the dashed y=x line indicate non-normality." />
         </div>

--- a/src/components/ApneaClusterAnalysis.jsx
+++ b/src/components/ApneaClusterAnalysis.jsx
@@ -1,15 +1,12 @@
 import React, { useState, useMemo, useCallback } from 'react';
-import Plot from 'react-plotly.js';
-import { useEffectiveDarkMode } from '../hooks/useEffectiveDarkMode';
 import { clustersToCsv } from '../utils/clustering';
-import { applyChartTheme } from '../utils/chartTheme';
+import ThemedPlot from './ThemedPlot';
 import GuideLink from './GuideLink';
 import VizHelp from './VizHelp';
 
 function ApneaClusterAnalysis({ clusters, params, onParamChange, details }) {
   const [selected, setSelected] = useState(null);
   const [sortBy, setSortBy] = useState({ key: 'severity', dir: 'desc' });
-  const isDark = useEffectiveDarkMode();
   const sorted = [...clusters].sort((a, b) => {
     const dir = sortBy.dir === 'asc' ? 1 : -1;
     const va = a[sortBy.key] ?? 0;
@@ -203,8 +200,7 @@ function ApneaClusterAnalysis({ clusters, params, onParamChange, details }) {
         <div>
           <h3>Event-level Timeline for Cluster #{selected + 1}</h3>
           <div className="chart-with-help">
-            <Plot
-              key={isDark ? 'dark-cluster' : 'light-cluster'}
+            <ThemedPlot
               data={[
                 {
                   type: 'bar',
@@ -221,7 +217,7 @@ function ApneaClusterAnalysis({ clusters, params, onParamChange, details }) {
                   ),
                 },
               ]}
-              layout={applyChartTheme(isDark, {
+              layout={{
                 title: `Cluster #${selected + 1} Event Timeline`,
                 xaxis: { type: 'date', title: 'Event Start Time' },
                 yaxis: { title: 'Event #' },
@@ -230,7 +226,7 @@ function ApneaClusterAnalysis({ clusters, params, onParamChange, details }) {
                   200,
                   sorted[selected].events.length * 30 + 100
                 ),
-              })}
+              }}
               config={{ displayModeBar: false }}
             />
             <VizHelp text="Horizontal bars show individual event durations positioned by start time. Longer bars mean longer apneas within the selected cluster." />
@@ -242,8 +238,7 @@ function ApneaClusterAnalysis({ clusters, params, onParamChange, details }) {
         <div>
           <h3>Leak/Pressure around Cluster</h3>
           <div className="chart-with-help">
-            <Plot
-              key={isDark ? 'dark-leak-pressure' : 'light-leak-pressure'}
+            <ThemedPlot
               data={[
                 leakTrace.length && {
                   type: 'scatter',
@@ -262,7 +257,7 @@ function ApneaClusterAnalysis({ clusters, params, onParamChange, details }) {
                   yaxis: leakTrace.length ? 'y2' : 'y1',
                 },
               ].filter(Boolean)}
-              layout={applyChartTheme(isDark, {
+              layout={{
                 title: 'Leak/Pressure around Cluster',
                 xaxis: { type: 'date', title: 'Time' },
                 yaxis: {
@@ -280,7 +275,7 @@ function ApneaClusterAnalysis({ clusters, params, onParamChange, details }) {
                   : {}),
                 margin: { l: 80, r: 20, t: 40, b: 40 },
                 height: 300,
-              })}
+              }}
               config={{ displayModeBar: false }}
             />
             <VizHelp text="Leak and pressure traces provide context around the cluster window." />

--- a/src/components/ApneaEventStats.jsx
+++ b/src/components/ApneaEventStats.jsx
@@ -1,11 +1,9 @@
 import React, { useMemo } from 'react';
-import Plot from 'react-plotly.js';
 import { computeApneaEventStats, kmSurvival } from '../utils/stats';
-import { useEffectiveDarkMode } from '../hooks/useEffectiveDarkMode';
-import { applyChartTheme } from '../utils/chartTheme';
+import { useData } from '../context/DataContext';
+import ThemedPlot from './ThemedPlot';
 import VizHelp from './VizHelp';
 import GuideLink from './GuideLink';
-import { useData } from '../context/DataContext';
 
 /**
  * Displays statistics and charts for individual apnea event durations
@@ -18,7 +16,6 @@ export default function ApneaEventStats() {
     () => kmSurvival(stats.durations || []),
     [stats.durations]
   );
-  const isDark = useEffectiveDarkMode();
   if (!stats.totalEvents) {
     return null;
   }
@@ -78,8 +75,7 @@ export default function ApneaEventStats() {
       </table>
       <div className="usage-charts-grid">
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-hist' : 'light-hist'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -90,18 +86,17 @@ export default function ApneaEventStats() {
                 name: 'Duration Dist',
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'Distribution of Apnea Durations',
               xaxis: { title: 'Duration (s)' },
               yaxis: { title: 'Count' },
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
           />
           <VizHelp text="Distribution of individual apnea event durations. Helps spot unusually long events." />
         </div>
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-box' : 'light-box'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -113,19 +108,18 @@ export default function ApneaEventStats() {
                 marker: { color: '#888' },
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'Apnea Duration Boxplot',
               yaxis: { title: 'Duration (s)', zeroline: false },
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
           />
           <VizHelp text="Boxplot of apnea event durations; box shows IQR, whiskers typical range, points outliers." />
         </div>
       </div>
 
       <div className="chart-item chart-with-help">
-        <Plot
-          key={isDark ? 'dark-surv' : 'light-surv'}
+        <ThemedPlot
           useResizeHandler
           style={{ width: '100%', height: '300px' }}
           data={[
@@ -162,12 +156,12 @@ export default function ApneaEventStats() {
               line: { width: 2, color: '#1f77b4', shape: 'hv' },
             },
           ]}
-          layout={applyChartTheme(isDark, {
+          layout={{
             title: 'Apnea Event Duration Survival (KM)',
             xaxis: { title: 'Duration (s)' },
             yaxis: { title: 'Survival P(T > t)', rangemode: 'tozero' },
             margin: { t: 40, l: 60, r: 20, b: 50 },
-          })}
+          }}
           config={{ responsive: true, displaylogo: false }}
         />
         <VizHelp text="KaplanâMeier survival of event durations (probability an event exceeds t seconds). Shaded band is the approximate 95% CI." />
@@ -204,8 +198,7 @@ export default function ApneaEventStats() {
       </table>
       <div className="usage-charts-grid">
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-line' : 'light-line'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -218,18 +211,17 @@ export default function ApneaEventStats() {
                 line: { width: 1 },
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'Apnea Events per Night',
               xaxis: { title: 'Date' },
               yaxis: { title: 'Count' },
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
           />
           <VizHelp text="Events per night over time; look for spikes that may indicate rough nights." />
         </div>
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-night-hist' : 'light-night-hist'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -240,12 +232,12 @@ export default function ApneaEventStats() {
                 name: 'Events/night Dist',
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'Distribution of Events per Night',
               xaxis: { title: 'Count' },
               yaxis: { title: 'Nights' },
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
           />
           <VizHelp text="Distribution of nightly event counts; the shape shows how often high/low event nights occur." />
         </div>

--- a/src/components/EpapTrendsCharts.jsx
+++ b/src/components/EpapTrendsCharts.jsx
@@ -1,9 +1,8 @@
 import React, { useMemo } from 'react';
-import Plot from 'react-plotly.js';
 import { COLORS } from '../utils/colors';
 import { useEffectiveDarkMode } from '../hooks/useEffectiveDarkMode';
-import { applyChartTheme } from '../utils/chartTheme';
 import VizHelp from './VizHelp';
+import ThemedPlot from './ThemedPlot';
 import {
   mannWhitneyUTest,
   pearson,
@@ -268,8 +267,7 @@ function EpapTrendsCharts({ data }) {
   return (
     <div className="usage-charts">
       <div className="chart-with-help">
-        <Plot
-          key={isDark ? 'dark' : 'light'}
+        <ThemedPlot
           useResizeHandler
           style={{ width: '100%', height: '300px' }}
           data={[
@@ -298,13 +296,13 @@ function EpapTrendsCharts({ data }) {
               marker: { color: COLORS.secondary, size: 6 },
             },
           ]}
-          layout={applyChartTheme(isDark, {
+          layout={{
             title: 'Nightly Median EPAP Over Time',
             legend: { orientation: 'h', x: 0.5, xanchor: 'center' },
             xaxis: { title: 'Date' },
             yaxis: { title: 'EPAP (cmH₂O)' },
             margin: { t: 40, l: 60, r: 20, b: 50 },
-          })}
+          }}
           config={{
             responsive: true,
             displaylogo: false,
@@ -317,8 +315,7 @@ function EpapTrendsCharts({ data }) {
 
       <div className="usage-charts-grid">
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-box' : 'light-box'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -330,12 +327,12 @@ function EpapTrendsCharts({ data }) {
                 marker: { color: COLORS.box },
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'Boxplot of Nightly Median EPAP',
               legend: { orientation: 'h', x: 0.5, xanchor: 'center' },
               yaxis: { title: 'EPAP (cmH₂O)', zeroline: false },
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
             config={{
               responsive: true,
               displaylogo: false,
@@ -346,8 +343,7 @@ function EpapTrendsCharts({ data }) {
           <VizHelp text="Boxplot of nightly median EPAP; box shows IQR and points indicate outliers." />
         </div>
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-scatter' : 'light-scatter'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -396,13 +392,13 @@ function EpapTrendsCharts({ data }) {
                   ]
                 : []),
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: `EPAP vs AHI Scatter (r = ${corr.toFixed(2)})`,
               legend: { orientation: 'h', x: 0.5, xanchor: 'center' },
               xaxis: { title: 'Median EPAP (cmH₂O)' },
               yaxis: { title: 'AHI (events/hour)' },
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
             config={{
               responsive: true,
               displaylogo: false,
@@ -416,8 +412,7 @@ function EpapTrendsCharts({ data }) {
           <VizHelp text="Scatter of nightly EPAP vs AHI. Dots are nights; dashed line is linear fit; purple line is LOESS smoother; green/red lines are running p50/p90 quantiles." />
         </div>
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-2d' : 'light-2d'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -428,12 +423,12 @@ function EpapTrendsCharts({ data }) {
                 colorscale: 'Viridis',
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'EPAP vs AHI Density (2D Histogram)',
               xaxis: { title: 'Median EPAP (cmH₂O)' },
               yaxis: { title: 'AHI (events/hour)' },
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
             config={{ responsive: true, displaylogo: false }}
           />
           <VizHelp text="2D histogram density of EPAP vs AHI, highlighting common combinations." />
@@ -445,8 +440,7 @@ function EpapTrendsCharts({ data }) {
           className="chart-item chart-with-help"
           style={{ marginTop: '16px' }}
         >
-          <Plot
-            key={isDark ? 'dark-corr' : 'light-corr'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -469,7 +463,7 @@ function EpapTrendsCharts({ data }) {
                 reversescale: !isDark,
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'Correlation Matrix (Pearson r)',
               autosize: true,
               xaxis: { title: 'Variable' },
@@ -484,7 +478,7 @@ function EpapTrendsCharts({ data }) {
                   font: { color: isDark ? '#fff' : '#000' },
                 }))
               ),
-            })}
+            }}
             config={{ responsive: true, displaylogo: false }}
           />
           <VizHelp text="Correlation matrix (Pearson r) among available variables; cell labels show the correlation value." />
@@ -496,8 +490,7 @@ function EpapTrendsCharts({ data }) {
           className="chart-item chart-with-help"
           style={{ marginTop: '12px' }}
         >
-          <Plot
-            key={isDark ? 'dark-corr-partial' : 'light-corr-partial'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -520,7 +513,7 @@ function EpapTrendsCharts({ data }) {
                 reversescale: !isDark,
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'Partial Correlation (controls: Usage, Leak)',
               autosize: true,
               xaxis: { title: 'Variable' },
@@ -535,7 +528,7 @@ function EpapTrendsCharts({ data }) {
                   font: { color: isDark ? '#fff' : '#000' },
                 }))
               ),
-            })}
+            }}
             config={{ responsive: true, displaylogo: false }}
           />
           <VizHelp text="Partial correlations controlling for Usage and Leak (if available). Helps assess EPAP–AHI relationship net of confounding." />
@@ -546,8 +539,7 @@ function EpapTrendsCharts({ data }) {
       {corrMatrix.leakMed && corrMatrix.leakMed.length ? (
         <div className="usage-charts-grid" style={{ marginTop: '16px' }}>
           <div className="chart-item chart-with-help">
-            <Plot
-              key={isDark ? 'dark-leak' : 'light-leak'}
+            <ThemedPlot
               useResizeHandler
               style={{ width: '100%', height: '300px' }}
               data={[
@@ -559,36 +551,34 @@ function EpapTrendsCharts({ data }) {
                   name: 'Leak Median',
                 },
               ]}
-              layout={applyChartTheme(isDark, {
+              layout={{
                 title: 'Leak Median Over Time',
                 xaxis: { title: 'Date' },
                 yaxis: { title: 'Leak (median)' },
                 margin: { t: 40, l: 60, r: 20, b: 50 },
-              })}
+              }}
               config={{ responsive: true, displaylogo: false }}
             />
             <VizHelp text="Leak median over time if available; trends can indicate mask fit or seal issues." />
           </div>
           <div className="chart-item chart-with-help">
-            <Plot
-              key={isDark ? 'dark-leak-hist' : 'light-leak-hist'}
+            <ThemedPlot
               useResizeHandler
               style={{ width: '100%', height: '300px' }}
               data={[{ x: corrMatrix.leakMed, type: 'histogram', nbinsx: 20 }]}
-              layout={applyChartTheme(isDark, {
+              layout={{
                 title: 'Leak Median Distribution',
                 xaxis: { title: 'Leak (median)' },
                 yaxis: { title: 'Count' },
                 margin: { t: 40, l: 60, r: 20, b: 50 },
-              })}
+              }}
               config={{ responsive: true, displaylogo: false }}
             />
             <VizHelp text="Distribution of nightly leak median values; helps identify consistent high-leak nights." />
           </div>
           {corrMatrix.leakPct && corrMatrix.leakPct.length ? (
             <div className="chart-item chart-with-help">
-              <Plot
-                key={isDark ? 'dark-leak-pct' : 'light-leak-pct'}
+              <ThemedPlot
                 useResizeHandler
                 style={{ width: '100%', height: '300px' }}
                 data={[
@@ -600,12 +590,12 @@ function EpapTrendsCharts({ data }) {
                     name: 'Leak % above thr',
                   },
                 ]}
-                layout={applyChartTheme(isDark, {
+                layout={{
                   title: 'Time Above Leak Threshold (%)',
                   xaxis: { title: 'Date' },
                   yaxis: { title: 'Percent of night (%)' },
                   margin: { t: 40, l: 60, r: 20, b: 50 },
-                })}
+                }}
                 config={{ responsive: true, displaylogo: false }}
               />
               <VizHelp text="Percent of each night above leak threshold; persistent high percentages may impair therapy." />

--- a/src/components/FalseNegativesAnalysis.jsx
+++ b/src/components/FalseNegativesAnalysis.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import Plot from 'react-plotly.js';
 import { FALSE_NEG_CONFIDENCE_MIN } from '../utils/clustering';
-import { applyChartTheme } from '../utils/chartTheme';
-import { useEffectiveDarkMode } from '../hooks/useEffectiveDarkMode';
 import GuideLink from './GuideLink';
 import VizHelp from './VizHelp';
+import ThemedPlot from './ThemedPlot';
 
 function FalseNegativesAnalysis({ list, preset, onPresetChange }) {
-  const prefersDark = useEffectiveDarkMode();
   return (
     <div>
       <h2 id="false-negatives">
@@ -43,8 +40,7 @@ function FalseNegativesAnalysis({ list, preset, onPresetChange }) {
       <div>
         <h3>False Negative Clusters by Confidence Over Time</h3>
         <div className="chart-with-help">
-          <Plot
-            key={prefersDark ? 'dark-fn' : 'light-fn'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '400px' }}
             data={[
@@ -69,7 +65,7 @@ function FalseNegativesAnalysis({ list, preset, onPresetChange }) {
                 hovertemplate: '%{text}<extra></extra>',
               },
             ]}
-            layout={applyChartTheme(prefersDark, {
+            layout={{
               title: 'False Negative Clusters by Confidence Over Time',
               xaxis: { type: 'date', title: 'Cluster Start Time' },
               yaxis: {
@@ -78,7 +74,7 @@ function FalseNegativesAnalysis({ list, preset, onPresetChange }) {
               },
               margin: { l: 80, r: 20, t: 40, b: 40 },
               height: 400,
-            })}
+            }}
             config={{ responsive: true, displaylogo: false }}
           />
           <VizHelp text="Each dot is a potential false-negative cluster. Position shows time and confidence; marker size scales with duration and color encodes confidence." />

--- a/src/components/ThemedPlot.jsx
+++ b/src/components/ThemedPlot.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Plot from 'react-plotly.js';
+import { useEffectiveDarkMode } from '../hooks/useEffectiveDarkMode';
+import { applyChartTheme } from '../utils/chartTheme';
+
+export default function ThemedPlot({ layout, ...props }) {
+  const isDark = useEffectiveDarkMode();
+  const themedLayout = applyChartTheme(isDark, layout);
+  return (
+    <Plot key={isDark ? 'dark' : 'light'} layout={themedLayout} {...props} />
+  );
+}

--- a/src/components/ThemedPlot.test.jsx
+++ b/src/components/ThemedPlot.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+import Plot from 'react-plotly.js';
+import * as darkHook from '../hooks/useEffectiveDarkMode';
+import ThemedPlot from './ThemedPlot';
+
+describe('ThemedPlot', () => {
+  beforeEach(() => {
+    Plot.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('applies light theme layout when dark mode is disabled', () => {
+    vi.spyOn(darkHook, 'useEffectiveDarkMode').mockReturnValue(false);
+    render(<ThemedPlot data={[]} />);
+    const layout = Plot.mock.calls[0][0].layout;
+    expect(layout.paper_bgcolor).toBe('#ffffff');
+  });
+
+  it('applies dark theme layout when dark mode is enabled', () => {
+    vi.spyOn(darkHook, 'useEffectiveDarkMode').mockReturnValue(true);
+    render(<ThemedPlot data={[]} />);
+    const layout = Plot.mock.calls[0][0].layout;
+    expect(layout.paper_bgcolor).toBe('#121821');
+  });
+});

--- a/src/components/UsagePatternsCharts.jsx
+++ b/src/components/UsagePatternsCharts.jsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useCallback } from 'react';
-import Plot from 'react-plotly.js';
 import {
   parseDuration,
   quantile,
@@ -10,7 +9,7 @@ import {
 } from '../utils/stats';
 import { COLORS } from '../utils/colors';
 import { useEffectiveDarkMode } from '../hooks/useEffectiveDarkMode';
-import { applyChartTheme } from '../utils/chartTheme';
+import ThemedPlot from './ThemedPlot';
 import VizHelp from './VizHelp';
 
 /**
@@ -179,8 +178,7 @@ function UsagePatternsCharts({ data, onRangeSelect }) {
       </div>
       {/* Time-series usage with rolling average, full-width responsive */}
       <div className="chart-with-help">
-        <Plot
-          key={isDark ? 'dark' : 'light'}
+        <ThemedPlot
           useResizeHandler
           style={{ width: '100%', height: '300px' }}
           data={[
@@ -255,7 +253,7 @@ function UsagePatternsCharts({ data, onRangeSelect }) {
               line: { dash: 'dot', width: 2, color: COLORS.accent },
             },
           ]}
-          layout={applyChartTheme(isDark, {
+          layout={{
             title: 'Nightly Usage Hours Over Time',
             legend: { orientation: 'h', x: 0.5, xanchor: 'center' },
             xaxis: { title: 'Date' },
@@ -281,7 +279,7 @@ function UsagePatternsCharts({ data, onRangeSelect }) {
                 line: { color: '#6a3d9a', width: 2 },
               })) || []),
             ],
-          })}
+          }}
           onRelayout={handleRelayout}
           config={{
             responsive: true,
@@ -299,8 +297,7 @@ function UsagePatternsCharts({ data, onRangeSelect }) {
       {/* Histogram and boxplot side-by-side on large screens, stacked on narrow */}
       <div className="usage-charts-grid">
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-hist' : 'light-hist'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -312,7 +309,7 @@ function UsagePatternsCharts({ data, onRangeSelect }) {
                 marker: { color: COLORS.primary },
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'Distribution of Nightly Usage',
               legend: { orientation: 'h', x: 0.5, xanchor: 'center' },
               xaxis: { title: 'Hours' },
@@ -356,7 +353,7 @@ function UsagePatternsCharts({ data, onRangeSelect }) {
                 },
               ],
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
             config={{
               responsive: true,
               displaylogo: false,
@@ -370,8 +367,7 @@ function UsagePatternsCharts({ data, onRangeSelect }) {
           <VizHelp text="Distribution of nightly usage hours. Dashed line marks the median; dotted line marks the mean." />
         </div>
         <div className="chart-item chart-with-help">
-          <Plot
-            key={isDark ? 'dark-box' : 'light-box'}
+          <ThemedPlot
             useResizeHandler
             style={{ width: '100%', height: '300px' }}
             data={[
@@ -383,12 +379,12 @@ function UsagePatternsCharts({ data, onRangeSelect }) {
                 marker: { color: COLORS.box },
               },
             ]}
-            layout={applyChartTheme(isDark, {
+            layout={{
               title: 'Boxplot of Nightly Usage',
               legend: { orientation: 'h', x: 0.5, xanchor: 'center' },
               yaxis: { title: 'Hours of Use', zeroline: false },
               margin: { t: 40, l: 60, r: 20, b: 50 },
-            })}
+            }}
             config={{
               responsive: true,
               displaylogo: false,
@@ -404,8 +400,7 @@ function UsagePatternsCharts({ data, onRangeSelect }) {
       </div>
       {/* Weekly calendar heatmap (Mon–Sun by columns of weeks) */}
       <div className="chart-item chart-with-help" style={{ marginTop: '16px' }}>
-        <Plot
-          key={isDark ? 'dark-heat' : 'light-heat'}
+        <ThemedPlot
           useResizeHandler
           style={{ width: '100%', height: '220px' }}
           data={[
@@ -428,12 +423,12 @@ function UsagePatternsCharts({ data, onRangeSelect }) {
                 '%{y} %{x|%Y-%m-%d}<br>Hours: %{z:.2f}<extra></extra>',
             },
           ]}
-          layout={applyChartTheme(isDark, {
+          layout={{
             title: 'Calendar Heatmap of Usage (hours)',
             xaxis: { title: 'Week', type: 'date', tickformat: '%Y-%m-%d' },
             yaxis: { title: 'Day of Week', autorange: 'reversed' },
             margin: { t: 40, l: 60, r: 20, b: 50 },
-          })}
+          }}
           config={{ responsive: true, displaylogo: false }}
         />
         <VizHelp text="Calendar heatmap of nightly usage by day of week; darker tiles indicate more hours of use." />

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,11 +3,11 @@ import React from 'react';
 import { vi } from 'vitest';
 
 // Mock Plotly charts to simplify component tests
+const plotlyMock = vi.fn((props) =>
+  React.createElement('div', { 'data-testid': 'plotly-chart', ...props })
+);
 vi.mock('react-plotly.js', () => {
-  return {
-    default: (props) =>
-      React.createElement('div', { 'data-testid': 'plotly-chart', ...props }),
-  };
+  return { default: plotlyMock };
 });
 
 // Provide a minimal IntersectionObserver polyfill for jsdom


### PR DESCRIPTION
## Summary
- introduce `<ThemedPlot>` that applies dark/light themes automatically
- refactor chart components to use `<ThemedPlot>`
- test plot theming for dark and light modes

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c030689e88832f8ceff1dc19b5f0eb