### PR TITLE
feat: centralize shared constants

### DIFF
--- a/docs/developer/adding-features.md
+++ b/docs/developer/adding-features.md
@@ -4,4 +4,5 @@
 2. Write colocated tests with the `.test.jsx` suffix using Testing Library.
 3. Expose state or parameters via `DataContext` hooks as needed.
 4. Add routes or buttons in `App.jsx` to surface new visualizations.
-5. Update documentation and run `npm run lint` and `npm test -- --run` before committing.
+5. Place shared configuration values in `src/constants.js` so they can be reused across modules.
+6. Update documentation and run `npm run lint` and `npm test -- --run` before committing.

--- a/src/components/EpapTrendsCharts.jsx
+++ b/src/components/EpapTrendsCharts.jsx
@@ -9,6 +9,7 @@ import {
   loessSmooth,
   runningQuantileXY,
 } from '../utils/stats';
+import { LOESS_SAMPLE_STEPS } from '../constants';
 
 /**
  * EPAP Analysis Charts: boxplot of nightly median EPAP,
@@ -85,7 +86,7 @@ function EpapTrendsCharts({ data }) {
     if (!epaps.length) return [];
     const min = Math.min(...epaps);
     const max = Math.max(...epaps);
-    const steps = 60;
+    const steps = LOESS_SAMPLE_STEPS;
     const arr = [];
     const step = (max - min) / Math.max(1, steps - 1);
     for (let i = 0; i < steps; i++) arr.push(min + i * step);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,16 @@
+/**
+ * Global configuration constants for the OSCAR Export Analyzer.
+ * Each value is documented with units to aid maintenance.
+ */
+
+/**
+ * Additional time window checked before and after an apnea cluster to ensure
+ * no annotated events occur nearby. Measured in milliseconds.
+ */
+export const EVENT_WINDOW_MS = 5000;
+
+/**
+ * Number of evenly spaced sample points used when generating LOESS trend
+ * lines in charts. Unitless count.
+ */
+export const LOESS_SAMPLE_STEPS = 60;

--- a/src/utils/clustering.js
+++ b/src/utils/clustering.js
@@ -1,5 +1,7 @@
 // Utility functions for clustering apnea annotation events and detecting false negatives.
 
+import { EVENT_WINDOW_MS } from '../constants';
+
 // Default parameters for apnea clustering
 const DEFAULT_APNEA_GAP_SEC = 120; // max gap (sec) between annotation events to cluster
 const DEFAULT_FLG_BRIDGE_THRESHOLD = 0.1; // FLG level to bridge annotation events (low threshold)
@@ -182,8 +184,8 @@ export function detectFalseNegatives(details, opts = {}) {
         const t = new Date(r['DateTime']).getTime();
         return (
           ['ClearAirway', 'Obstructive', 'Mixed'].includes(r['Event']) &&
-          t >= cl.start.getTime() - 5000 &&
-          t <= cl.end.getTime() + 5000
+          t >= cl.start.getTime() - EVENT_WINDOW_MS &&
+          t <= cl.end.getTime() + EVENT_WINDOW_MS
         );
       });
     })

--- a/src/utils/clustering.test.js
+++ b/src/utils/clustering.test.js
@@ -5,6 +5,7 @@ import {
   computeClusterSeverity,
   clustersToCsv,
 } from './clustering';
+import { EVENT_WINDOW_MS } from '../constants';
 
 describe('clusterApneaEvents', () => {
   it('returns empty array when no events', () => {
@@ -22,7 +23,7 @@ describe('clusterApneaEvents', () => {
     const [c] = clusters;
     // start at first event, end at last event + its duration
     expect(c.start).toEqual(base);
-    expect(c.end.getTime()).toBe(base.getTime() + 50000 + 5000);
+    expect(c.end.getTime()).toBe(base.getTime() + 50000 + EVENT_WINDOW_MS);
     expect(c.count).toBe(2);
   });
 


### PR DESCRIPTION
## Summary
- add `src/constants.js` with documented `EVENT_WINDOW_MS` and `LOESS_SAMPLE_STEPS`
- replace magic numbers in clustering utils and EPAP trend charts with shared constants
- update tests and developer guide for new constants module

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c05618bb88832fa097dafb6e8657d1