### PR TITLE
refactor: centralize normal quantile utility

### DIFF
--- a/docs/user/04-statistical-concepts.md
+++ b/docs/user/04-statistical-concepts.md
@@ -1,36 +1,40 @@
 # Statistical Concepts
 
-The analyzer applies a number of statistical techniques to summarize and compare therapy data.  This chapter explains each method so results can be interpreted with confidence.
+The analyzer applies a number of statistical techniques to summarize and compare therapy data. This chapter explains each method so results can be interpreted with confidence.
 
 ## Rolling Windows
-Many charts show 7‑ and 30‑night rolling averages to smooth nightly variation.  For a series $x_1, x_2, …, x_n$, the rolling mean of window $k$ at night $t$ is:
+
+Many charts show 7‑ and 30‑night rolling averages to smooth nightly variation. For a series $x_1, x_2, …, x_n$, the rolling mean of window $k$ at night $t$ is:
 
 $$
 \text{RollingMean}_k(t) = \frac{1}{k} \sum_{i=t-k+1}^{t} x_i
 $$
 
-Rolling medians are computed by sorting the last $k$ values and selecting the middle element.  Windows include calendar days with missing data so gaps do not over‑weight subsequent nights.
+Rolling medians are computed by sorting the last $k$ values and selecting the middle element. Windows include calendar days with missing data so gaps do not over‑weight subsequent nights.
 
 ## Confidence Intervals
+
 To convey uncertainty, rolling means are accompanied by 95 % confidence intervals assuming approximately normal residuals:
 
 $$
 \text{CI}_{95} = \bar{x} \pm 1.96 \frac{s}{\sqrt{k}}
 $$
 
-where $\bar{x}$ is the window mean and $s$ is the sample standard deviation.  For medians we use order‑statistic bounds derived from the binomial distribution.
+where $\bar{x}$ is the window mean and $s$ is the sample standard deviation. For medians we use order‑statistic bounds derived from the binomial distribution.
 
 ## Change‑Point Detection
-The analyzer marks structural breaks in usage and AHI series using least‑squares segmentation.  The algorithm partitions the series into segments where the mean is relatively stable.  Change‑points can highlight the start of a new therapy regimen or periods of non‑adherence.
+
+The analyzer marks structural breaks in usage and AHI series using least‑squares segmentation. The algorithm partitions the series into segments where the mean is relatively stable. Change‑points can highlight the start of a new therapy regimen or periods of non‑adherence.
 
 ## Mann–Whitney U Test
-When comparing two date ranges, we avoid assumptions of normality by using the Mann–Whitney U test.  Given groups $A$ and $B$:
+
+When comparing two date ranges, we avoid assumptions of normality by using the Mann–Whitney U test. Given groups $A$ and $B$:
 
 $$
 U_A = n_A n_B + \frac{n_A(n_A + 1)}{2} - R_A
 $$
 
-where $R_A$ is the sum of ranks assigned to group $A$.  The `p`‑value indicates whether the distributions differ; the rank‑biserial effect size is computed as:
+where $R_A$ is the sum of ranks assigned to group $A$. The `p`‑value indicates whether the distributions differ; the rank‑biserial effect size is computed as:
 
 $$
 \text{RB} = 1 - \frac{2U}{n_A n_B}
@@ -39,10 +43,16 @@ $$
 with $U = \min(U_A, U_B)$.
 
 ## LOESS and Quantile Bands
-Locally Estimated Scatterplot Smoothing (LOESS) fits a smooth curve to the EPAP×AHI scatter plot.  It uses weighted least squares with tri‑cube kernel and span parameter `α` (default 0.5).  The running quantile bands show the 50th and 90th percentile of AHI for each pressure bucket, illustrating how the bulk and tail of the distribution shift with pressure.
+
+Locally Estimated Scatterplot Smoothing (LOESS) fits a smooth curve to the EPAP×AHI scatter plot. It uses weighted least squares with tri‑cube kernel and span parameter `α` (default 0.5). The running quantile bands show the 50th and 90th percentile of AHI for each pressure bucket, illustrating how the bulk and tail of the distribution shift with pressure.
+
+## QQ Plot
+
+Quantile–quantile plots compare the sorted nightly AHI values to the theoretical quantiles of a normal distribution. The theoretical quantiles are computed using a Beasley–Springer/Moro approximation to the inverse normal CDF. Points that stray from the diagonal line indicate departures from normality such as skew or heavy tails.
 
 ## Partial Correlation
-To isolate the relationship between two variables while controlling for others, we compute the partial correlation.  For variables $X$, $Y$, and control variable $Z$:
+
+To isolate the relationship between two variables while controlling for others, we compute the partial correlation. For variables $X$, $Y$, and control variable $Z$:
 
 $$
 r_{XY \cdot Z} = \frac{r_{XY} - r_{XZ} r_{YZ}}{\sqrt{(1 - r_{XZ}^2)(1 - r_{YZ}^2)}}
@@ -51,16 +61,18 @@ $$
 This is especially useful when examining EPAP vs. AHI while accounting for usage or leak rate.
 
 ## Survival Analysis
-Kaplan–Meier curves estimate the probability that an apnea event lasts longer than $t$ seconds.  The survival function is:
+
+Kaplan–Meier curves estimate the probability that an apnea event lasts longer than $t$ seconds. The survival function is:
 
 $$
 S(t) = \prod_{t_i \le t} \left(1 - \frac{d_i}{n_i}\right)
 $$
 
-where $d_i$ is the number of events ending at time $t_i$ and $n_i$ is the number still active just before $t_i$.  Steeper drops indicate many long events.
+where $d_i$ is the number of events ending at time $t_i$ and $n_i$ is the number still active just before $t_i$. Steeper drops indicate many long events.
 
 ## Clustering Parameters
-Apnea clusters are sequences of events separated by less than a specified gap (default 90 s).  Optionally, flow‑limitation segments can bridge gaps shorter than the **FLG bridge** parameter.  The severity score for a cluster is:
+
+Apnea clusters are sequences of events separated by less than a specified gap (default 90 s). Optionally, flow‑limitation segments can bridge gaps shorter than the **FLG bridge** parameter. The severity score for a cluster is:
 
 $$
 \text{Severity} = \frac{\text{EventCount}}{\text{Duration}}
@@ -69,7 +81,8 @@ $$
 Clusters with high severity may indicate positional apnea or inadequate pressure response.
 
 ## False‑Negative Presets
-The analyzer scans for intervals of sustained high flow limitation that lack apnea labels.  Presets adjust three thresholds:
+
+The analyzer scans for intervals of sustained high flow limitation that lack apnea labels. Presets adjust three thresholds:
 
 - **FLG Threshold** – Minimum flow‑limitation level.
 - **Minimum Duration** – Minimum length of the interval.

--- a/src/components/AhiTrendsCharts.jsx
+++ b/src/components/AhiTrendsCharts.jsx
@@ -4,6 +4,7 @@ import {
   detectUsageBreakpoints,
   computeUsageRolling,
   detectChangePoints,
+  normalQuantile,
 } from '../utils/stats';
 import { COLORS } from '../utils/colors';
 import ThemedPlot from './ThemedPlot';
@@ -112,37 +113,6 @@ export default function AhiTrendsCharts({
     sorted.reduce((s, v) => s + (v - mu) ** 2, 0) / Math.max(1, n - 1)
   );
   const probs = sorted.map((_, i) => (i + 1) / (n + 1));
-  const normalQuantile = (p) => {
-    // Beasley-Springer/Moro approx via inverse error function
-    const a = [2.50662823884, -18.61500062529, 41.39119773534, -25.44106049637];
-    const b = [-8.4735109309, 23.08336743743, -21.06224101826, 3.13082909833];
-    const c = [
-      0.3374754822726147, 0.9761690190917186, 0.1607979714918209,
-      0.0276438810333863, 0.0038405729373609, 0.0003951896511919,
-      0.0000321767881768, 0.0000002888167364, 0.0000003960315187,
-    ];
-    const y = p - 0.5;
-    if (Math.abs(y) < 0.42) {
-      const r = y * y;
-      const num = y * (((a[3] * r + a[2]) * r + a[1]) * r + a[0]);
-      const den = (((b[3] * r + b[2]) * r + b[1]) * r + b[0]) * r + 1;
-      return num / den;
-    }
-    let r = p;
-    if (y > 0) r = 1 - p;
-    r = Math.log(-Math.log(r));
-    let x =
-      c[0] +
-      r *
-        (c[1] +
-          r *
-            (c[2] +
-              r *
-                (c[3] +
-                  r *
-                    (c[4] + r * (c[5] + r * (c[6] + r * (c[7] + r * c[8])))))));
-    return y < 0 ? -x : x;
-  };
   const theo = probs.map((p) => mu + sigma * normalQuantile(p));
 
   // Bad-night tagging with explanations

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -21,15 +21,13 @@ export function parseDuration(s, opts = {}) {
   }
   const parts = s.split(':');
   if (parts.length === 0 || parts.length > 3) {
-    if (throwOnError)
-      throw new Error(`Invalid duration format: ${s}`);
+    if (throwOnError) throw new Error(`Invalid duration format: ${s}`);
     return NaN;
   }
   const nums = [];
   for (const p of parts) {
     if (!/^\d+(?:\.\d+)?$/.test(p)) {
-      if (throwOnError)
-        throw new Error(`Invalid duration segment: ${p}`);
+      if (throwOnError) throw new Error(`Invalid duration segment: ${p}`);
       return NaN;
     }
     nums.push(parseFloat(p));
@@ -535,6 +533,38 @@ export function spearman(x, y) {
   const rx = rank(x);
   const ry = rank(y);
   return pearson(rx, ry);
+}
+
+// Standard normal quantile (inverse CDF) approximation
+// Uses the Beasley-Springer/Moro algorithm for high accuracy
+export function normalQuantile(p) {
+  const a = [2.50662823884, -18.61500062529, 41.39119773534, -25.44106049637];
+  const b = [-8.4735109309, 23.08336743743, -21.06224101826, 3.13082909833];
+  const c = [
+    0.3374754822726147, 0.9761690190917186, 0.1607979714918209,
+    0.0276438810333863, 0.0038405729373609, 0.0003951896511919,
+    0.0000321767881768, 0.0000002888167364, 0.0000003960315187,
+  ];
+  const y = p - 0.5;
+  if (Math.abs(y) < 0.42) {
+    const r = y * y;
+    const num = y * (((a[3] * r + a[2]) * r + a[1]) * r + a[0]);
+    const den = (((b[3] * r + b[2]) * r + b[1]) * r + b[0]) * r + 1;
+    return num / den;
+  }
+  let r = p;
+  if (y > 0) r = 1 - p;
+  r = Math.log(-Math.log(r));
+  let x =
+    c[0] +
+    r *
+      (c[1] +
+        r *
+          (c[2] +
+            r *
+              (c[3] +
+                r * (c[4] + r * (c[5] + r * (c[6] + r * (c[7] + r * c[8])))))));
+  return y < 0 ? -x : x;
 }
 
 // Standard normal CDF approximation

--- a/src/utils/stats.test.js
+++ b/src/utils/stats.test.js
@@ -17,6 +17,7 @@ import {
   pearson,
 } from './stats';
 import { kmSurvival } from './stats';
+import { normalQuantile, normalCdf } from './stats';
 
 describe('parseDuration', () => {
   it('parses HH:MM:SS format', () => {
@@ -149,6 +150,21 @@ describe('quantile', () => {
 
   it('interpolates for even-length array', () => {
     expect(quantile([0, 10], 0.5)).toBe(5);
+  });
+});
+
+describe('normalQuantile', () => {
+  it('inverts normalCdf at common probabilities', () => {
+    const probs = [0.025, 0.5, 0.975];
+    probs.forEach((p) => {
+      const z = normalQuantile(p);
+      expect(normalCdf(z)).toBeCloseTo(p, 4);
+    });
+  });
+
+  it('matches known z-scores', () => {
+    expect(normalQuantile(0.841344746)).toBeCloseTo(1, 4);
+    expect(normalQuantile(0.158655254)).toBeCloseTo(-1, 4);
   });
 });
 


### PR DESCRIPTION
## Summary
- move normalQuantile to shared stats utils and export it
- import normalQuantile in AhiTrendsCharts and remove inline implementation
- document QQ plot math and add unit tests to verify numerical accuracy

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c062b6d6bc832fb08dcf6fa096144b