### PR TITLE
feat: use functional error boundary

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -2,7 +2,6 @@
 
 The app is a Vite + React single page application.
 
-- **Component Hierarchy**: `App` hosts file pickers and analysis sections. Visualization components live in `src/components` and are wrapped with `ErrorBoundary` as needed.
-- **Component Hierarchy**: `App` hosts file pickers and analysis sections. Visualization components live in `src/components` and are wrapped with `ErrorBoundary` as needed. Charts should use `ThemedPlot` to automatically apply light or dark styling.
+- **Component Hierarchy**: `App` hosts file pickers and analysis sections. Visualization components live in `src/components` and are wrapped with a functional `ErrorBoundary` (via `react-error-boundary`) as needed. Charts should use `ThemedPlot` to automatically apply light or dark styling.
 - **State Management**: `DataContext` provides parsed CSV data, parameters, and theme. Hooks such as `useData` and `useTheme` access and update this state.
 - **Data Flow**: Uploaded CSVs are parsed with PapaParse in a worker. Results are stored in context and passed to chart components. Additional workers handle cluster and false-negative analysis.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "plotly.js-basic-dist": "^2.35.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^6.0.0",
         "react-markdown": "^10.1.0",
         "react-plotly.js": "^2.6.0",
         "rehype-katex": "^7.0.0",
@@ -322,7 +323,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -9492,6 +9492,18 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
+      "integrity": "sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
     "plotly.js-basic-dist": "^2.35.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^6.0.0",
     "react-markdown": "^10.1.0",
+    "react-plotly.js": "^2.6.0",
     "rehype-katex": "^7.0.0",
     "remark-gfm": "^4.0.0",
-    "remark-math": "^6.0.0",
-    "react-plotly.js": "^2.6.0"
+    "remark-math": "^6.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,28 +1,19 @@
 import React from 'react';
+import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary';
 
-class ErrorBoundary extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
-
-  componentDidCatch(error, errorInfo) {
-    console.error('ErrorBoundary caught an error', error, errorInfo);
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div role="alert">{this.props.fallback || 'Something went wrong.'}</div>
-      );
-    }
-
-    return this.props.children;
-  }
+function ErrorBoundary({ fallback, children }) {
+  return (
+    <ReactErrorBoundary
+      FallbackComponent={() => (
+        <div role="alert">{fallback || 'Something went wrong.'}</div>
+      )}
+      onError={(error, info) => {
+        console.error('ErrorBoundary caught an error', error, info);
+      }}
+    >
+      {children}
+    </ReactErrorBoundary>
+  );
 }
 
 export default ErrorBoundary;

--- a/src/components/ErrorBoundary.test.jsx
+++ b/src/components/ErrorBoundary.test.jsx
@@ -28,6 +28,15 @@ describe('ErrorBoundary', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('fallback text');
   });
 
+  it('logs errors via console.error', () => {
+    render(
+      <ErrorBoundary fallback="fallback text">
+        <Bomb />
+      </ErrorBoundary>
+    );
+    expect(console.error).toHaveBeenCalled();
+  });
+
   it('renders children when there is no error', () => {
     render(
       <ErrorBoundary fallback="fallback text">


### PR DESCRIPTION
## Summary
- replace class-based ErrorBoundary with functional wrapper using `react-error-boundary`
- log errors and support fallback UI via `react-error-boundary`
- add test to verify error handling and update docs
- remove duplicate "Component Hierarchy" entry in architecture docs

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c06defcb94832f83a4e0634cf3bb6d