### PR TITLE
fix: generate deterministic tooltip ids

### DIFF
--- a/src/components/VizHelp.jsx
+++ b/src/components/VizHelp.jsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useId } from 'react';
 
 /**
  * Small inline help tooltip for visualizations.
+ * Uses `useId` for a deterministic tooltip id; pass `id` to override.
  * Usage: place inside a relatively positioned container.
  */
 export default function VizHelp({ text, id, style, inline = true }) {
-  const tipId = id || `viz-tip-${Math.random().toString(36).slice(2)}`;
+  const generatedId = useId();
+  const tipId = id || `viz-tip-${generatedId}`;
   const className = `viz-help ${inline ? 'viz-inline' : 'viz-overlay'}`;
   const posStyle = inline
     ? {}

--- a/src/components/VizHelp.test.jsx
+++ b/src/components/VizHelp.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import VizHelp from './VizHelp';
+
+describe('VizHelp', () => {
+  it('generates a stable id and associates tooltip', () => {
+    const { rerender } = render(<VizHelp text="Help text" />);
+    const trigger = screen.getByTestId('viz-help');
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip.id).toMatch(/^viz-tip-/);
+    expect(trigger).toHaveAttribute('aria-describedby', tooltip.id);
+    const firstId = tooltip.id;
+    rerender(<VizHelp text="Help text" />);
+    expect(screen.getByRole('tooltip').id).toBe(firstId);
+  });
+
+  it('uses provided id when supplied', () => {
+    render(<VizHelp text="Help text" id="custom-id" />);
+    const trigger = screen.getByTestId('viz-help');
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip.id).toBe('custom-id');
+    expect(trigger).toHaveAttribute('aria-describedby', 'custom-id');
+  });
+});


### PR DESCRIPTION
## Summary
- replace `Math.random` with React `useId` in `VizHelp` for stable tooltip identifiers
- allow passing an `id` prop to override the generated one
- add unit tests covering default ID generation and custom `id` override

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c06dea651c832fabed89d85cba0c08