### PR TITLE
fix: ignore NaN pairs in pearson correlation

### DIFF
--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -81,7 +81,7 @@ export function computeApneaEventStats(details) {
   const countOver30 = durations.filter((v) => v > 30).length;
   const countOver60 = durations.filter((v) => v > 60).length;
   const countOutlierEvents = durations.filter(
-    (v) => v >= p75Dur + 1.5 * iqrDur
+    (v) => v >= p75Dur + 1.5 * iqrDur,
   ).length;
 
   // Compute events per night
@@ -108,10 +108,10 @@ export function computeApneaEventStats(details) {
   const minNight = eventsPerNight.length ? Math.min(...eventsPerNight) : 0;
   const maxNight = eventsPerNight.length ? Math.max(...eventsPerNight) : 0;
   const outlierNightHigh = eventsPerNight.filter(
-    (v) => v >= p75Night + 1.5 * iqrNight
+    (v) => v >= p75Night + 1.5 * iqrNight,
   ).length;
   const outlierNightLow = eventsPerNight.filter(
-    (v) => v <= p25Night - 1.5 * iqrNight
+    (v) => v <= p25Night - 1.5 * iqrNight,
   ).length;
 
   return {
@@ -157,10 +157,10 @@ export function summarizeUsage(data) {
   const p75Hours = quantile(usageHours, 0.75);
   const iqrHours = p75Hours - p25Hours;
   const outlierLowCount = usageHours.filter(
-    (h) => h < p25Hours - 1.5 * iqrHours
+    (h) => h < p25Hours - 1.5 * iqrHours,
   ).length;
   const outlierHighCount = usageHours.filter(
-    (h) => h > p75Hours + 1.5 * iqrHours
+    (h) => h > p75Hours + 1.5 * iqrHours,
   ).length;
   return {
     totalNights,
@@ -236,7 +236,7 @@ export function computeUsageRolling(dates, usageHours, windows = [7, 30]) {
         // mean CI via normal approx: m ± 1.96 * s/√n
         const variance = Math.max(
           0,
-          (sumsq - (sum * sum) / len) / Math.max(1, len - 1)
+          (sumsq - (sum * sum) / len) / Math.max(1, len - 1),
         );
         const se = Math.sqrt(variance) / Math.sqrt(len);
         const z = 1.96;
@@ -297,7 +297,7 @@ export function detectUsageBreakpoints(
   rolling7,
   rolling30,
   dates,
-  minDelta = 0.75
+  minDelta = 0.75,
 ) {
   const points = [];
   for (let i = 1; i < rolling7.length; i++) {
@@ -443,16 +443,16 @@ export function computeEPAPTrends(data) {
   const cov =
     epapAhiPairs.reduce(
       (sum, [p, a]) => sum + (p - meanEpap) * (a - meanAhi),
-      0
+      0,
     ) /
     (epapAhiPairs.length - 1);
   const stdEp = Math.sqrt(
     epapAhiPairs.reduce((sum, [p]) => sum + (p - meanEpap) ** 2, 0) /
-      (epapAhiPairs.length - 1)
+      (epapAhiPairs.length - 1),
   );
   const stdAh = Math.sqrt(
     epapAhiPairs.reduce((sum, [, a]) => sum + (a - meanAhi) ** 2, 0) /
-      (epapAhiPairs.length - 1)
+      (epapAhiPairs.length - 1),
   );
   const corrEPAPAHI = cov / (stdEp * stdAh);
   const lowGroup = data
@@ -491,8 +491,8 @@ export function computeEPAPTrends(data) {
 // Pearson correlation helper
 export function pearson(x, y) {
   const n = Math.min(x.length, y.length);
-  if (n < 2) return NaN;
-  let sx = 0,
+  let count = 0,
+    sx = 0,
     sy = 0,
     sxx = 0,
     syy = 0,
@@ -501,15 +501,17 @@ export function pearson(x, y) {
     const xi = x[i];
     const yi = y[i];
     if (!isFinite(xi) || !isFinite(yi)) continue;
+    count++;
     sx += xi;
     sy += yi;
     sxx += xi * xi;
     syy += yi * yi;
     sxy += xi * yi;
   }
-  const cov = (sxy - (sx * sy) / n) / (n - 1);
-  const vx = (sxx - (sx * sx) / n) / (n - 1);
-  const vy = (syy - (sy * sy) / n) / (n - 1);
+  if (count < 2) return NaN;
+  const cov = (sxy - (sx * sy) / count) / count;
+  const vx = (sxx - (sx * sx) / count) / count;
+  const vy = (syy - (sy * sy) / count) / count;
   const denom = Math.sqrt(vx) * Math.sqrt(vy);
   return denom ? cov / denom : NaN;
 }
@@ -918,7 +920,7 @@ function invertMatrix(A) {
   const n = A.length;
   // Create augmented [A | I]
   const M = A.map((row, i) =>
-    row.concat(Array.from({ length: n }, (_, j) => (i === j ? 1 : 0)))
+    row.concat(Array.from({ length: n }, (_, j) => (i === j ? 1 : 0))),
   );
   // Gauss-Jordan elimination
   for (let col = 0; col < n; col++) {

--- a/src/utils/stats.test.js
+++ b/src/utils/stats.test.js
@@ -35,7 +35,7 @@ describe('parseDuration', () => {
 
   it('throws on malformed input when requested', () => {
     expect(() => parseDuration('bad', { throwOnError: true })).toThrow(
-      /invalid duration/i
+      /invalid duration/i,
     );
   });
 });
@@ -68,6 +68,24 @@ describe('partialCorrelation (controls reduce confounding)', () => {
     const controls = z.map((v) => [v]);
     const pc = partialCorrelation(x, y, controls);
     expect(Math.abs(pc)).toBeLessThan(Math.abs(naive));
+  });
+});
+
+describe('pearson', () => {
+  it('ignores NaN pairs without skewing results', () => {
+    const x = [1, 2, 3, NaN];
+    const y = [1, 2, 3, 4];
+    const fx = [1, 2, 3];
+    const fy = [1, 2, 3];
+    expect(pearson(x, y)).toBeCloseTo(pearson(fx, fy));
+  });
+
+  it('ignores NaNs in either array', () => {
+    const x = [1, 2, 3, 4];
+    const y = [1, 2, NaN, 4];
+    const fx = [1, 2, 4];
+    const fy = [1, 2, 4];
+    expect(pearson(x, y)).toBeCloseTo(pearson(fx, fy));
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure `pearson` correlation only counts finite `(xi, yi)` pairs
- add tests covering NaN pairs to avoid skewed results

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build` *(fails: process hangs at `transforming...`)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c84efdc0832fb09fefd61afbdd9f