### PR TITLE
feat: allow overriding base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ The analyzer is implemented as a [Vite](https://vitejs.dev/) + [React](https://r
    ```
 4. Open the URL printed in the terminal (usually <http://localhost:5173>) in a modern browser.
 
+To deploy the app under a custom path, set the `BASE_URL` environment variable before building:
+
+```bash
+BASE_URL=/custom/ npm run build
+```
+
+If `BASE_URL` is unset, the build defaults to `/oscar-export-analyzer/`.
+
 ## Usage Walkthrough
 
 1. Export `Summary.csv` and optionally `Details.csv` from OSCAR.

--- a/docs/developer/setup.md
+++ b/docs/developer/setup.md
@@ -82,8 +82,8 @@ Vite serves the optimized bundle so you can sanity‑check assets and network re
 
 ### Environment Tips
 
-- The app has no environment‑specific configuration beyond the Node version. If you need to tweak build behavior, see
-  `vite.config.js`.
+- The app has no environment‑specific configuration beyond the Node version, but you can override the base path for built
+  assets by setting `BASE_URL` before running `npm run build`. See `vite.config.js` for additional options.
 - When debugging workers, open the browser's dev tools and check the "Sources" panel under `Workers` for logs and stack
   traces.
 - Some tests rely on jsdom features that lag behind real browsers. If a test fails in jsdom but works in Chromium,

--- a/src/viteConfig.test.js
+++ b/src/viteConfig.test.js
@@ -1,0 +1,18 @@
+/* @vitest-environment node */
+import { describe, it, expect, vi } from 'vitest';
+
+describe('vite config base path', () => {
+  it('uses BASE_URL when provided', async () => {
+    process.env.BASE_URL = '/custom/';
+    vi.resetModules();
+    const config = (await import('../vite.config.js')).default;
+    expect(config.base).toBe('/custom/');
+  });
+
+  it('falls back to default base when BASE_URL is undefined', async () => {
+    delete process.env.BASE_URL;
+    vi.resetModules();
+    const config = (await import('../vite.config.js')).default;
+    expect(config.base).toBe('/oscar-export-analyzer/');
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
+import process from 'node:process';
 
 export default defineConfig({
+  base: process.env.BASE_URL || '/oscar-export-analyzer/',
   plugins: [
     react(),
     visualizer({ filename: 'stats.html', template: 'treemap', open: false }),


### PR DESCRIPTION
## Summary
- allow customizing Vite base URL through BASE_URL env var
- document BASE_URL usage in README and developer setup guide
- add tests ensuring base URL uses environment variable or default

## Testing
- `npm run lint`
- `npm test -- --run`
- `npx vitest run src/viteConfig.test.js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0cd96a1e8832fbea7ba5d3a378f62