### PR TITLE
chore: deploy GitHub Pages preview after PR approval

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,26 +1,77 @@
-name: Pages
+name: Build and Deploy Website
 
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
   group: pages
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  deploy-preview:
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+      pull-requests: write
+    environment:
+      name: pr-preview
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Project
+        run: npm run build -- --base "${{ steps.pages.outputs.base_path }}/"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Comment PR with preview URL
+        if: steps.deployment.outputs.page_url
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `Preview: ${process.env.DEPLOY_URL}`
+            });
+        env:
+          DEPLOY_URL: ${{ steps.deployment.outputs.page_url }}
+
+  deploy-production:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -36,7 +87,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
+      - name: Build Project
         run: npm run build -- --base "${{ steps.pages.outputs.base_path }}/"
 
       - name: Upload artifact
@@ -44,8 +95,7 @@ jobs:
         with:
           path: dist/
 
-      - name: Deploy
+      - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        with:
-          preview: ${{ github.event_name == 'pull_request' }}
+

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ npm test -- --run
 npm run build
 ```
 
-Production builds are deployed to GitHub Pages. Pushes to `main` update the live site, while pull requests receive temporary preview deployments via `.github/workflows/pages.yml`.
+Production builds are deployed to GitHub Pages. Pushes to `main` update the live site, while approved pull requests trigger temporary preview deployments via `.github/workflows/pages.yml`. After approving a PR, authorize the `pr-preview` environment to publish the preview.
 
 See the [Developer Guide](docs/developer/README.md) for testing patterns and architectural notes.
 


### PR DESCRIPTION
## Summary
- deploy PR previews only after a review is approved
- keep production deploy on pushes to `main`
- document how to authorize the `pr-preview` environment

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0de8a7828832fb902854c1521bc20