### PR TITLE
feat: add print page control and print styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 This repo contains a Vite + React app for analyzing OSCAR sleep data, with tests via Vitest and Testing Library. Use Node 20 and npm.
 
 ## Project Structure & Module Organization
+
 - `src/`: React app code.
   - `components/`, `utils/`, `hooks/`, `App.jsx`, `main.jsx`.
   - Tests colocated as `*.test.jsx|js` next to code.
@@ -11,6 +12,7 @@ This repo contains a Vite + React app for analyzing OSCAR sleep data, with tests
 - `.github/workflows/ci.yml`: CI for build and tests.
 
 ## Build, Test, and Development Commands
+
 - `npm run dev`: start Vite dev server with HMR.
 - `npm run build`: create production build to `dist/`.
 - `npm run preview`: serve the production build locally.
@@ -23,6 +25,7 @@ This repo contains a Vite + React app for analyzing OSCAR sleep data, with tests
 - `npm run format`: apply Prettier formatting.
 
 ## Coding Style & Naming Conventions
+
 - Indentation: 2 spaces; semicolons optional but be consistent.
 - Components: `PascalCase` filenames (e.g., `UsagePatternsCharts.jsx`).
 - Functions/vars: `camelCase`; constants: `UPPER_SNAKE_CASE`.
@@ -30,17 +33,19 @@ This repo contains a Vite + React app for analyzing OSCAR sleep data, with tests
 - ESLint and Prettier are configured; run `npm run lint` and `npm run format` to maintain code quality.
 
 ## Testing Guidelines
+
 - Frameworks: Vitest + @testing-library/react + jsdom.
 - Naming: `ComponentName.test.jsx` or `module.test.js` colocated with code.
 - Expectations: add tests for new logic and bug fixes; prefer user-facing assertions.
 - Run locally: `npm test` (watch mode) or `npm test -- --run` (single run); check coverage via `npm run test:coverage`.
 
 ## Commit & Pull Request Guidelines
+
 - Style: prefer Conventional Commits (e.g., `feat:`, `fix:`, `chore:`) as in history.
 - Pre-commit: Husky runs `npm run lint`, `npm test`, and `npm run build`; ensure all pass and builds have no warnings.
 - PRs: include clear description, linked issues, and screenshots/GIFs for UI changes. Ensure CI (lint, build, tests) passes.
 
 ## Security & Configuration Tips
+
 - Node: use version 20 (see CI). Avoid committing data exports containing sensitive information.
 - Vite config: see `vite.config.js`. For hooks, run `npm run prepare` after install.
-

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@ This document proposes a significant, non-breaking revamp that keeps all current
 ---
 
 ## 1. Vision & Goals
+
 - Rich insights: elevate from charts to explainable, actionable summaries and narratives.
 - Statistical rigor: quantiles, confidence intervals, change-points, and correlation tests.
 - Data-science UX: responsive, filterable, exportable views with reproducible state.
@@ -12,6 +13,7 @@ This document proposes a significant, non-breaking revamp that keeps all current
 - Accessibility: keyboard-first, high-contrast, and screen-reader friendly.
 
 ## 2. High-Level User Flows
+
 1. Upload CSVs (Summary + Details) with schema validation and helpful errors.
 2. Parse/compute in Web Workers with determinate progress and cancellation.
 3. Dashboard Overview with KPI cards, sparklines, and narrative insights.
@@ -21,16 +23,19 @@ This document proposes a significant, non-breaking revamp that keeps all current
 ## 3. Architecture & Data Pipeline
 
 ### 3.1 Web Workers and Streaming
+
 - Move heavy calculations to dedicated workers (parser + analytics) using Comlink.
 - Stream parse with PapaParse; push partial aggregates to UI for immediate feedback.
 - Support cancellation/retry; show stepwise progress (parse → compute → render).
 
 ### 3.2 State and Persistence
+
 - Lift global state to Context or Zustand; keep App.jsx lean and declarative.
 - Persist parsed blobs and computed metrics in IndexedDB (opt-in, with “Clear data”).
 - URL hash/state export for sharable, reproducible views without uploading data.
 
 ### 3.3 Module Organization (target)
+
 ```
 src/
 ├── components/
@@ -70,12 +75,14 @@ src/
 ## 4. Feature Roadmap & Visualizations
 
 ### 4.1 Usage Patterns (expand, keep existing)
+
 - 7/30-night moving averages with adherence streaks and breakpoints (change-point detection via simple CUSUM/PELT).
 - Day-of-week and weekly heatmap of usage hours; calendar heatmap (GitHub-style).
 - Compliance KPIs: percent nights ≥ 4h and ≥ 6h; rolling compliance window.
 - Distribution: histogram + box/violin; annotate median/mean and IQR whiskers (already partly present).
 
 ### 4.2 AHI Trends (expand, keep existing)
+
 - Decompose AHI into OAI/CAI/MAI if columns exist; stacked band chart over time. [Implemented]
 - Change-points using 7d vs 30d crossovers; markers on time-series. [Implemented]
 - Bad-night tagging and explanations (e.g., long clusters, high CA%) [Pending: requires integration across views]
@@ -83,6 +90,7 @@ src/
 - QQ-plot vs normal and violin distribution. [Implemented]
 
 ### 4.3 Pressure & Leak (rename from Pressure Settings; keep EPAP views)
+
 - Add leak metrics (if present in Summary): nightly median leak and histogram. [Implemented]
 - Time-above-leak threshold (if a suitable column exists) [Implemented] – auto-detect columns matching leak percentage/time-above
 - Correlation matrix: EPAP, AHI, usage, leak (Pearson) [Implemented]
@@ -90,6 +98,7 @@ src/
 - 2D density/hexbin: EPAP vs AHI. [Implemented]
 
 ### 4.4 Event Clusters (keep and enrich)
+
 - Parameter panel: gap sec, FLG thresholds, min counts; live recompute in worker. [Implemented]
 - Severity score per cluster: total duration, density, and FLG edge strength; sortable table. [Implemented]
 - Interactive Gantt: brush to zoom, cross-highlight with details table.
@@ -97,43 +106,51 @@ src/
 - Overlay leak/pressure traces (if available) around cluster window for context. [Implemented]
 
 ### 4.5 Potential False Negatives (keep and enrich)
+
 - Threshold tuning UI with presets. [Implemented]
 - Display ROC-style guidance based on retrospective labels (if user marks reviewed).
 - Review workflow: mark as reviewed/hidden; persist in IndexedDB; export reviewed set.
 - Explainability: show top drivers (duration, peak FLG) and nearby annotated events.
 
 ### 4.6 Raw Data Explorer (add, do not replace)
+
 - Virtualized, column-configurable table for Summary and Details with filters, sort, and search. [Implemented]
 - Pivot-like aggregations (group by date, event type) and quick stats footer. [Implemented]
 - Cross-filtering: selecting ranges updates charts; reset/undo controls. [Implemented]
 - Export selected rows/slices to CSV. [Implemented]
 
 ### 4.7 Reporting & Export
+
 - One-click PDF: Overview KPIs, key charts, and narrative insights with timestamps and parameters.
 - CSV exports: summary metrics, cluster intervals, false-negative candidates.
 - JSON session: data fingerprints + visualization state for reproducibility/sharing (without data upload). [Implemented]
 
 ### 4.8 Reproducibility & Notebooks (optional, scientist-friendly)
+
 - Export tidy CSV/Parquet; provide Python/R snippets to replicate core charts.
 - Document data dictionary and column mapping.
 
 ## 5. Asynchronous Feedback & UX
+
 - Determinate progress per step; clear error toasts with actionable fixes (missing columns, bad dates).
 - Disable dependent tabs until ready; skeleton loaders; retry buttons.
 - Keyboard shortcuts for navigation; persistent parameter panel; responsive grid layout.
 
 ## 6. Performance & Scalability
+
 - Workers for parse/analytics; debounce UI updates; chunked aggregation.
 - Virtualize big tables; lazy-render heavy charts; memoize derived series.
 - Cache parsed/computed artifacts; estimate memory usage and allow user to clear data.
 
 ## 7. Libraries & Tooling
+
 - Charts: keep Plotly for interactivity; consider lightweight alt (Recharts) for small charts.
 - Tables: TanStack Table (react-table) + react-window for virtualization; AG Grid if needed.
 - Workers: Comlink; structured clones for typed payloads.
 - State: Zustand or Context + reducer; React Router for tabs.
 
 ## 8. Documentation Improvements (README)
+
 - Features overview with screenshots/GIFs; architecture diagram (workers, state, views).
 - Data requirements: expected CSV columns, sample files, and known OSCAR quirks.
 - Privacy: client-side only, no uploads; how to clear local data.
@@ -142,23 +159,26 @@ src/
 - CLI section for `analysis.js` with examples; link to advanced usage.
 
 ## 9. Non-Breaking Principle
+
 - Keep all existing charts and flows; reorganize into tabs and add layers/controls.
 - New features behind sensible defaults; parameters surfaced but pre-populated with current values.
 
 ## 10. Milestones & Timeline
-| Week | Deliverable |
-| ---- | ----------- |
-| 1    | Worker scaffolding + global state + error toasts |
+
+| Week | Deliverable                                          |
+| ---- | ---------------------------------------------------- |
+| 1    | Worker scaffolding + global state + error toasts     |
 | 2    | Overview KPIs + narrative + screenshots/docs updates |
-| 3    | Usage revamp (heatmaps, change-points) |
-| 4    | AHI revamp (stratification, distributions) |
-| 5    | EPAP/Leak correlations + tests |
-| 6    | Clusters panel w/ parameters + Gantt upgrades |
-| 7    | False negatives review workflow |
-| 8    | Raw Data Explorer + exports |
-| 9    | PDF/CSV/JSON exports + polish + a11y |
+| 3    | Usage revamp (heatmaps, change-points)               |
+| 4    | AHI revamp (stratification, distributions)           |
+| 5    | EPAP/Leak correlations + tests                       |
+| 6    | Clusters panel w/ parameters + Gantt upgrades        |
+| 7    | False negatives review workflow                      |
+| 8    | Raw Data Explorer + exports                          |
+| 9    | PDF/CSV/JSON exports + polish + a11y                 |
 
 ## 11. Testing & Quality Assurance
+
 - Unit: stats edge-cases (quantiles, CIs), clustering boundaries, false-negative filters.
 - Hooks/State: worker messaging, loading/cancel paths, persistence.
 - Integration: upload → parse → compute → render flow; parameter changes recompute.
@@ -167,12 +187,14 @@ src/
 - Performance: synthetic large CSVs to assert render time budgets; memory ceiling warnings.
 
 ## 12. Future Directions
+
 - Baseline comparison (pre/post therapy); regimen comparisons across periods.
 - Positional/stage integration if available; symptom correlation (ESS input).
 - Lightweight anomaly detection (seasonal STL + z-score) and nudges.
 - Optional cloud sync/export integration without storing raw data.
 
 ## 13. Open Questions / Assumptions
+
 - Which OSCAR columns are consistently present across devices/versions?
 - Typical CSV sizes in the wild; target performance budgets?
 - Desired export formats for team sharing (PDF length, CSV columns)?

--- a/analysis.js
+++ b/analysis.js
@@ -61,7 +61,7 @@ async function run(detailFilePath, targetDateStr, opts = {}) {
     }
   }
   console.error(
-    `Parsed ${summaryEvents.length} apnea summary events, ${flgEvents.length} FLG events`
+    `Parsed ${summaryEvents.length} apnea summary events, ${flgEvents.length} FLG events`,
   );
 
   const clusters =
@@ -75,7 +75,7 @@ async function run(detailFilePath, targetDateStr, opts = {}) {
           edgeEnter,
           edgeExit,
           edgeMinDurSec,
-          minDensityPerMin
+          minDensityPerMin,
         )
       : [];
   const valid = clusters.filter((c) => {
@@ -89,7 +89,7 @@ async function run(detailFilePath, targetDateStr, opts = {}) {
   if (!valid.length) {
     console.log(
       `No apnea clusters (≥3 events and ≥${APOEA_CLUSTER_MIN_TOTAL_SEC}s total) found for`,
-      targetDateStr
+      targetDateStr,
     );
     return [];
   }
@@ -102,29 +102,29 @@ async function run(detailFilePath, targetDateStr, opts = {}) {
     console.log(`  Events:`);
     c.events.forEach((e) =>
       console.log(
-        `    ${e.type} @ ${e.date.toISOString()} dur=${e.durationSec}s`
-      )
+        `    ${e.type} @ ${e.date.toISOString()} dur=${e.durationSec}s`,
+      ),
     );
     const flgIn = flgEvents
       .filter((f) => f.date >= c.start && f.date <= c.end)
       .map((f) => f.level);
     if (flgIn.length)
       console.log(
-        `  FLG levels: min=${Math.min(...flgIn)}, max=${Math.max(...flgIn)} (${flgIn.length} samples)`
+        `  FLG levels: min=${Math.min(...flgIn)}, max=${Math.max(...flgIn)} (${flgIn.length} samples)`,
       );
     const pIn = pressureEvents
       .filter((p) => p.date >= c.start && p.date <= c.end)
       .map((p) => p.level);
     if (pIn.length)
       console.log(
-        `  Pressure:   min=${Math.min(...pIn)}, max=${Math.max(...pIn)}`
+        `  Pressure:   min=${Math.min(...pIn)}, max=${Math.max(...pIn)}`,
       );
     const eIn = epapEvents
       .filter((p) => p.date >= c.start && p.date <= c.end)
       .map((p) => p.level);
     if (eIn.length)
       console.log(
-        `  EPAP:       min=${Math.min(...eIn)}, max=${Math.max(...eIn)}`
+        `  EPAP:       min=${Math.min(...eIn)}, max=${Math.max(...eIn)}`,
       );
   });
   return valid;
@@ -136,7 +136,7 @@ module.exports = { run };
 const args = process.argv.slice(2);
 if (args.length < 1) {
   console.error(
-    'Usage: node analysis.js <detailsCsv> [YYYY-MM-DD] [gapSec] [flgBridgeThreshold] [flgClusterGapSec]'
+    'Usage: node analysis.js <detailsCsv> [YYYY-MM-DD] [gapSec] [flgBridgeThreshold] [flgClusterGapSec]',
   );
   process.exit(1);
 }

--- a/docs/user/01-getting-started.md
+++ b/docs/user/01-getting-started.md
@@ -1,16 +1,18 @@
 # OSCAR Export Analyzer — User Guide
 
-This guide shows how to load OSCAR CSV exports and interpret the resulting charts and tables.  It assumes you have already collected nightly therapy data with a PAP device and imported it into OSCAR.
+This guide shows how to load OSCAR CSV exports and interpret the resulting charts and tables. It assumes you have already collected nightly therapy data with a PAP device and imported it into OSCAR.
 
 ## 1. Preparing Your Data
+
 Before using the analyzer, export the necessary files from OSCAR:
 
 1. Open OSCAR and navigate to the patient profile of interest.
 2. From the **Data** menu choose **Export Data...**
-3. Select **Summary** and **Details** CSV exports.  The summary file contains one row per night; the details file lists individual apnea events and flow‑limitation intervals.
-4. Save the files to a convenient location.  Avoid renaming or modifying them so the analyzer can detect columns automatically.
+3. Select **Summary** and **Details** CSV exports. The summary file contains one row per night; the details file lists individual apnea events and flow‑limitation intervals.
+4. Save the files to a convenient location. Avoid renaming or modifying them so the analyzer can detect columns automatically.
 
 ### Summary CSV Columns
+
 The summary export typically includes:
 
 - `Date` – formatted as `YYYY-MM-DD`.
@@ -20,6 +22,7 @@ The summary export typically includes:
 - Optional leak statistics such as `Leak Rate Median` or `% Time above Leak Redline`.
 
 ### Details CSV Columns
+
 The details export provides higher fidelity information:
 
 - `Event` – `ClearAirway`, `Obstructive`, `Mixed`, or `FLG` (flow limitation).
@@ -27,17 +30,20 @@ The details export provides higher fidelity information:
 - `Data` or `Duration` – event duration in seconds or flow‑limitation magnitude.
 
 ## 2. Loading Files into the Analyzer
+
 1. Open <http://localhost:5173> after starting the development server or the deployed site if using a prebuilt bundle.
 2. Use the **Summary CSV** file input to choose the exported summary file.
-3. Optionally choose the **Details CSV** file.  Large files are parsed in a background worker and show progress bars.
+3. Optionally choose the **Details CSV** file. Large files are parsed in a background worker and show progress bars.
 4. Once loaded, the sidebar links become active and charts render automatically.
 
 ![File pickers with summary and details loaded](../images/getting-started-upload.png)
 
 ### Handling Large Files
-The parser streams rows so even multi‑year exports load gradually.  A counter displays how many rows have been processed and when parsing is complete.  If memory becomes an issue, consider trimming your export to a smaller date range.
+
+The parser streams rows so even multi‑year exports load gradually. A counter displays how many rows have been processed and when parsing is complete. If memory becomes an issue, consider trimming your export to a smaller date range.
 
 ## 3. Navigating the Interface
+
 The application is organized into several views accessible from the sidebar:
 
 - **Overview** – High‑level KPIs for usage and AHI.
@@ -48,26 +54,31 @@ The application is organized into several views accessible from the sidebar:
 - **Event Analysis** – Includes apnea duration distributions, cluster detection, and potential false negatives.
 - **Raw Data** – Tabular view of the CSV contents with filtering and export.
 
-Use the theme toggle in the header to switch between light, dark, or system themes.  The interface responds to window resizing and touch input for tablets.
+Use the theme toggle in the header to switch between light, dark, or system themes. The interface responds to window resizing and touch input for tablets.
 
 ## 4. Saving and Restoring Sessions
+
 When **Remember data locally** is enabled, files and settings persist to `IndexedDB` so you can close and reopen the browser without reloading data. Uploading a new Summary CSV replaces the previous session. The app only saves after at least one CSV has been loaded, preventing a refresh on an empty page from wiping prior data. The **Save/Load/Clear** controls manage that last session; choosing **Load Saved** replaces whatever files or settings are currently in memory. Disabling **Remember data locally** clears it. Use **Export JSON** to download a portable snapshot that can be imported on another device. The exported JSON includes all loaded rows but excludes any personal notes you may have added.
 
 ## 5. Example Workflow
+
 1. Load a year of summary and details data.
-2. Visit **Usage Patterns** to verify that at least 70% of nights exceed four hours of usage.  Investigate dips with the calendar heatmap.
-3. Open **AHI Trends** and note any nights above 5 AHI.  Use the table of "bad nights" to jot down potential causes in a journal.
-4. Go to **Pressure & Correlation** and check whether higher EPAP correlates with lower AHI.  If the LOESS trend slopes downward, discuss with your clinician whether pressure adjustments are warranted.
-5. Use **Range Comparison** to contrast the month before and after a mask change.  Look at `ΔUsage` and `ΔAHI` along with the `p`‑value to gauge the effect.
+2. Visit **Usage Patterns** to verify that at least 70% of nights exceed four hours of usage. Investigate dips with the calendar heatmap.
+3. Open **AHI Trends** and note any nights above 5 AHI. Use the table of "bad nights" to jot down potential causes in a journal.
+4. Go to **Pressure & Correlation** and check whether higher EPAP correlates with lower AHI. If the LOESS trend slopes downward, discuss with your clinician whether pressure adjustments are warranted.
+5. Use **Range Comparison** to contrast the month before and after a mask change. Look at `ΔUsage` and `ΔAHI` along with the `p`‑value to gauge the effect.
 
 ## 6. Keyboard Shortcuts
+
 - `?` – Open the help modal.
 - `t` – Toggle theme.
 - `s` – Save current session.
 - `l` – Load a saved session.
 
 ## 7. Troubleshooting
-See [06-troubleshooting.md](06-troubleshooting.md) for an extensive list of issues and remedies.  Common early hurdles include malformed CSV headers, missing columns, or browser extensions that block local file reads.
+
+See [06-troubleshooting.md](06-troubleshooting.md) for an extensive list of issues and remedies. Common early hurdles include malformed CSV headers, missing columns, or browser extensions that block local file reads.
 
 ## 8. Next Steps
+
 Once you are comfortable loading data and navigating the interface, explore the remaining chapters of the user guide to learn how to interpret specific visualizations and statistical outputs.

--- a/docs/user/02-visualizations.md
+++ b/docs/user/02-visualizations.md
@@ -109,7 +109,7 @@ A virtualized table renders the raw Summary and Details CSV contents. Features i
 - **Session Persistence** – Stores uploaded files and settings in `IndexedDB` when enabled.
 - **JSON Export/Import** – Saves or restores a session snapshot.
 - **Aggregates CSV** – Exports computed nightly metrics for external analysis.
-- **PDF Report** – Generates a print‑friendly summary with key charts and tables suitable for clinicians.
+- **Print Page** – The app's print control triggers your browser's print dialog. The print view omits navigation and buttons while keeping charts and summary tables for saving or sharing.
 
 ## Interpretation Tips
 

--- a/docs/user/05-faq.md
+++ b/docs/user/05-faq.md
@@ -18,7 +18,7 @@ When **Remember data locally** is enabled, files and settings are saved to Index
 
 ### Can I export results for my doctor?
 
-Use the print‑friendly PDF report or the aggregates CSV for sharing. The report contains key charts, while the aggregates file lists nightly usage, AHI, EPAP, and cluster metrics.
+Use the **Print Page** control to generate a PDF or the aggregates CSV for sharing. The print view hides navigation and buttons but preserves charts and summary tables.
 
 ### Is my data uploaded anywhere?
 

--- a/docs/user/07-practical-tips.md
+++ b/docs/user/07-practical-tips.md
@@ -3,28 +3,37 @@
 These suggestions help you get the most out of the OSCAR Export Analyzer and your therapy data.
 
 ## Analyze with Purpose
-Before diving into charts, decide what question you want to answer.  For example, “Did switching masks improve my AHI?” or “Is my usage declining on weekends?”  Having a hypothesis guides which views to explore and avoids fishing for patterns.
+
+Before diving into charts, decide what question you want to answer. For example, “Did switching masks improve my AHI?” or “Is my usage declining on weekends?” Having a hypothesis guides which views to explore and avoids fishing for patterns.
 
 ## Use Range Comparisons After Changes
-When you change equipment or settings, mark the date and use the **Range Comparisons** view to compare before and after periods.  Look at both `ΔUsage` and `ΔAHI` along with effect size to judge whether the change had a meaningful impact.
+
+When you change equipment or settings, mark the date and use the **Range Comparisons** view to compare before and after periods. Look at both `ΔUsage` and `ΔAHI` along with effect size to judge whether the change had a meaningful impact.
 
 ## Correlate with a Sleep Diary
-Quantitative data gains context when paired with qualitative notes.  Keep a diary of mask issues, bedtime habits, or medication changes.  Use the “bad nights” table in **AHI Trends** as a prompt to write down potential causes.
+
+Quantitative data gains context when paired with qualitative notes. Keep a diary of mask issues, bedtime habits, or medication changes. Use the “bad nights” table in **AHI Trends** as a prompt to write down potential causes.
 
 ## Monitor Long‑Term Adherence
-The calendar heatmap and 30‑night rolling averages in **Usage Patterns** reveal how habits evolve.  Aim for at least 70 % of nights over four hours of usage.  If you see a sustained decline, check equipment comfort or travel schedules.
+
+The calendar heatmap and 30‑night rolling averages in **Usage Patterns** reveal how habits evolve. Aim for at least 70 % of nights over four hours of usage. If you see a sustained decline, check equipment comfort or travel schedules.
 
 ## Investigate Clusters Carefully
-Clusters of events might point to positional apnea or mask leaks.  After identifying a severe cluster, open the timeline visualization, then return to OSCAR to inspect flow and pressure traces around that period.  Avoid over‑interpreting a single night—look for recurring patterns.
+
+Clusters of events might point to positional apnea or mask leaks. After identifying a severe cluster, open the timeline visualization, then return to OSCAR to inspect flow and pressure traces around that period. Avoid over‑interpreting a single night—look for recurring patterns.
 
 ## Share Reports with Professionals
-Export the PDF report or aggregates CSV and bring them to clinical appointments.  Visual summaries can make discussions more productive, but always defer to professional advice when considering therapy changes.
+
+Export the PDF report or aggregates CSV and bring them to clinical appointments. Visual summaries can make discussions more productive, but always defer to professional advice when considering therapy changes.
 
 ## Keep Raw Exports
-Store original OSCAR exports alongside your session JSON files.  Having raw data allows you to reproduce analyses later or try new tools without re‑exporting.
+
+Store original OSCAR exports alongside your session JSON files. Having raw data allows you to reproduce analyses later or try new tools without re‑exporting.
 
 ## Stay Up to Date
-Check the project repository periodically for updates.  New versions may include additional visualizations, bug fixes, or improved statistical methods.
+
+Check the project repository periodically for updates. New versions may include additional visualizations, bug fixes, or improved statistical methods.
 
 ## Respect Data Privacy
+
 If using shared computers, disable **Remember data locally** (which clears cached data) and delete any exported session files after use. Sensitive health information should be handled carefully.

--- a/docs/user/08-disclaimers.md
+++ b/docs/user/08-disclaimers.md
@@ -1,24 +1,29 @@
 # Disclaimers
 
-The OSCAR Export Analyzer is designed for educational and exploratory purposes.  Understanding its limitations is essential before acting on any insights produced by the tool.
+The OSCAR Export Analyzer is designed for educational and exploratory purposes. Understanding its limitations is essential before acting on any insights produced by the tool.
 
 ## Not a Medical Device
-This software is **not** approved by regulatory agencies such as the FDA or CE for diagnosis or treatment.  Charts and statistics are approximations that may omit clinical context.  Always consult a qualified sleep specialist before altering therapy settings or equipment.
+
+This software is **not** approved by regulatory agencies such as the FDA or CE for diagnosis or treatment. Charts and statistics are approximations that may omit clinical context. Always consult a qualified sleep specialist before altering therapy settings or equipment.
 
 ## Data Accuracy
-- OSCAR exports depend on accurate device recordings.  Corrupted SD cards, incorrect clock settings, or device malfunctions can lead to misleading results.
-- The analyzer performs basic validation but cannot detect every anomaly.  Review raw data in OSCAR when numbers appear implausible.
+
+- OSCAR exports depend on accurate device recordings. Corrupted SD cards, incorrect clock settings, or device malfunctions can lead to misleading results.
+- The analyzer performs basic validation but cannot detect every anomaly. Review raw data in OSCAR when numbers appear implausible.
 
 ## Statistical Limitations
-- Small sample sizes yield unstable estimates.  For example, a single bad night can skew averages dramatically.
+
+- Small sample sizes yield unstable estimates. For example, a single bad night can skew averages dramatically.
 - The analyzer uses non‑parametric tests and heuristics for convenience; they are not substitutes for clinical studies.
 - Confidence intervals and `p`‑values rely on assumptions that may not hold for all datasets.
 
 ## Privacy and Security
+
 - All processing occurs locally, but you are responsible for safeguarding exported reports and JSON snapshots.
 - When sharing data, remove personally identifiable information and follow applicable privacy laws.
 
 ## No Warranty
-The software is provided “as is” without warranty of any kind.  The project maintainers are not liable for damages arising from use of the analyzer or reliance on its output.
+
+The software is provided “as is” without warranty of any kind. The project maintainers are not liable for damages arising from use of the analyzer or reliance on its output.
 
 By using the OSCAR Export Analyzer, you acknowledge these limitations and agree to use the tool responsibly.

--- a/src/App.csv-upload.test.jsx
+++ b/src/App.csv-upload.test.jsx
@@ -50,24 +50,24 @@ describe('CSV uploads and cross-component interactions', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('heading', { name: /Overview Dashboard/i })
+        screen.getByRole('heading', { name: /Overview Dashboard/i }),
       ).toBeInTheDocument();
     });
     expect(
-      screen.queryByRole('heading', { name: /Raw Data Explorer/i })
+      screen.queryByRole('heading', { name: /Raw Data Explorer/i }),
     ).not.toBeInTheDocument();
 
     const detailsInput = screen.getByLabelText(/Details CSV/i);
     const detailsFile = new File(
       ['Event,DateTime,Data/Duration\nClearAirway,2025-06-01T00:00:00,12'],
       'details.csv',
-      { type: 'text/csv' }
+      { type: 'text/csv' },
     );
     await userEvent.upload(detailsInput, detailsFile);
 
     await waitFor(() => {
       expect(
-        screen.getByRole('heading', { name: /Raw Data Explorer/i })
+        screen.getByRole('heading', { name: /Raw Data Explorer/i }),
       ).toBeInTheDocument();
     });
 
@@ -76,12 +76,12 @@ describe('CSV uploads and cross-component interactions', () => {
     expect(parseMock).toHaveBeenNthCalledWith(
       1,
       summaryFile,
-      expect.objectContaining({ worker: true })
+      expect.objectContaining({ worker: true }),
     );
     expect(parseMock).toHaveBeenNthCalledWith(
       2,
       detailsFile,
-      expect.objectContaining({ worker: true })
+      expect.objectContaining({ worker: true }),
     );
   });
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,11 +24,11 @@ import {
 import Overview from './components/Overview';
 const SummaryAnalysis = lazy(() => import('./components/SummaryAnalysis'));
 const ApneaClusterAnalysis = lazy(
-  () => import('./components/ApneaClusterAnalysis')
+  () => import('./components/ApneaClusterAnalysis'),
 );
 const ApneaEventStats = lazy(() => import('./components/ApneaEventStats'));
 const FalseNegativesAnalysis = lazy(
-  () => import('./components/FalseNegativesAnalysis')
+  () => import('./components/FalseNegativesAnalysis'),
 );
 import RangeComparisons from './components/RangeComparisons';
 import RawDataExplorer from './components/RawDataExplorer';
@@ -36,11 +36,7 @@ import ErrorBoundary from './components/ErrorBoundary';
 import ThemeToggle from './components/ThemeToggle';
 import DocsModal from './components/DocsModal';
 import GuideLink from './components/GuideLink';
-import {
-  buildSummaryAggregatesCSV,
-  downloadTextFile,
-  openPrintReportHTML,
-} from './utils/export';
+import { buildSummaryAggregatesCSV, downloadTextFile } from './utils/export';
 import { DataProvider } from './context/DataContext';
 
 function App() {
@@ -55,7 +51,7 @@ function App() {
       { id: 'false-negatives', label: 'False Negatives' },
       { id: 'raw-data-explorer', label: 'Raw Data' },
     ],
-    []
+    [],
   );
   const [activeId, setActiveId] = useState('overview');
   const {
@@ -184,7 +180,7 @@ function App() {
         // eslint-disable-next-line no-undef
         worker = new Worker(
           new URL('./workers/analytics.worker.js', import.meta.url),
-          { type: 'module' }
+          { type: 'module' },
         );
         worker.onmessage = (evt) => {
           if (cancelled) return;
@@ -196,7 +192,7 @@ function App() {
               .filter(
                 (cl) =>
                   cl.events.reduce((sum, e) => sum + e.durationSec, 0) >=
-                  clusterParams.minTotalSec
+                  clusterParams.minTotalSec,
               )
               .filter((cl) => cl.durationSec <= clusterParams.maxClusterSec)
               .map((cl) => ({ ...cl, severity: computeClusterSeverity(cl) }));
@@ -219,7 +215,7 @@ function App() {
       function fallbackCompute() {
         const apneaEvents = detailsData
           .filter((r) =>
-            ['ClearAirway', 'Obstructive', 'Mixed'].includes(r['Event'])
+            ['ClearAirway', 'Obstructive', 'Mixed'].includes(r['Event']),
           )
           .map((r) => ({
             date: new Date(r['DateTime']),
@@ -240,14 +236,14 @@ function App() {
           clusterParams.edgeEnter,
           clusterParams.edgeExit,
           10,
-          clusterParams.minDensity
+          clusterParams.minDensity,
         );
         const validClusters = rawClusters
           .filter((cl) => cl.count >= clusterParams.minCount)
           .filter(
             (cl) =>
               cl.events.reduce((sum, e) => sum + e.durationSec, 0) >=
-              clusterParams.minTotalSec
+              clusterParams.minTotalSec,
           )
           .filter((cl) => cl.durationSec <= clusterParams.maxClusterSec)
           .map((cl) => ({ ...cl, severity: computeClusterSeverity(cl) }));
@@ -332,7 +328,7 @@ function App() {
         // Trigger when headings cross just below the sticky header and before bottom of viewport
         rootMargin: `-${topMargin}px 0px -70% 0px`,
         threshold: [0, 0.25, 0.5, 0.75, 1],
-      }
+      },
     );
 
     // Observe any headings currently in the DOM
@@ -491,7 +487,7 @@ function App() {
                 downloadTextFile(
                   'aggregates.csv',
                   buildSummaryAggregatesCSV(summaryData || []),
-                  'text/csv'
+                  'text/csv',
                 )
               }
               disabled={!summaryData}
@@ -500,16 +496,10 @@ function App() {
             </button>
             <button
               className="btn-primary"
-              onClick={() =>
-                openPrintReportHTML(
-                  summaryData || [],
-                  apneaClusters || [],
-                  falseNegatives || []
-                )
-              }
+              onClick={() => window.print()}
               disabled={!summaryData}
             >
-              Open Print Report
+              Print Page
             </button>
           </div>
           <div

--- a/src/App.navigation.test.jsx
+++ b/src/App.navigation.test.jsx
@@ -44,13 +44,13 @@ describe('In-page navigation', () => {
     // Overview section should render (no Details required)
     await waitFor(() => {
       expect(
-        screen.getByRole('heading', { name: /Overview Dashboard/i })
+        screen.getByRole('heading', { name: /Overview Dashboard/i }),
       ).toBeInTheDocument();
     });
 
     // SummaryAnalysis section should also render
     expect(
-      await screen.findByRole('heading', { name: /Usage Patterns/i })
+      await screen.findByRole('heading', { name: /Usage Patterns/i }),
     ).toBeInTheDocument();
 
     // Clicking the Overview link should update the hash
@@ -62,7 +62,7 @@ describe('In-page navigation', () => {
     // Ensure Papa.parse was invoked using worker mode
     expect(parseMock).toHaveBeenCalledWith(
       file,
-      expect.objectContaining({ worker: true })
+      expect.objectContaining({ worker: true }),
     );
   });
 });

--- a/src/App.persistence.test.jsx
+++ b/src/App.persistence.test.jsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Papa from 'papaparse';
 import React from 'react';
@@ -153,7 +159,9 @@ describe('App persistence flow', () => {
     expect(cardEl).not.toBeNull();
     expect(within(cardEl).getByText('5.00')).toBeInTheDocument();
 
-    const loadSaved = screen.getByRole('button', { name: /load saved session/i });
+    const loadSaved = screen.getByRole('button', {
+      name: /load saved session/i,
+    });
     fireEvent.click(loadSaved);
 
     await waitFor(() => {
@@ -189,14 +197,26 @@ describe('App persistence flow', () => {
 
     memoryStore.last = buildSession({
       summaryData: [
-        { Date: '2021-01-01', 'Total Time': '1:00:00', AHI: '1', 'Median EPAP': '5' },
-        { Date: '2021-01-02', 'Total Time': 'bad', AHI: '2', 'Median EPAP': '6' },
+        {
+          Date: '2021-01-01',
+          'Total Time': '1:00:00',
+          AHI: '1',
+          'Median EPAP': '5',
+        },
+        {
+          Date: '2021-01-02',
+          'Total Time': 'bad',
+          AHI: '2',
+          'Median EPAP': '6',
+        },
       ],
       detailsData: [],
     });
 
     render(<App />);
-    const loadSaved = screen.getByRole('button', { name: /load saved session/i });
+    const loadSaved = screen.getByRole('button', {
+      name: /load saved session/i,
+    });
     fireEvent.click(loadSaved);
 
     await vi.waitFor(() => expect(spy).toHaveBeenCalled());
@@ -204,5 +224,4 @@ describe('App persistence flow', () => {
     expect(spy.mock.results.some((r) => Number.isNaN(r.value))).toBe(true);
     spy.mockRestore();
   });
-
 });

--- a/src/App.print.test.jsx
+++ b/src/App.print.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Papa from 'papaparse';
+import App from './App';
+
+describe('Print Page control', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('invokes window.print and hides old report button', async () => {
+    window.print = vi.fn();
+    vi.spyOn(Papa, 'parse').mockImplementation((file, options) => {
+      const rows = [
+        {
+          Date: '2025-06-01',
+          'Total Time': '08:00:00',
+          AHI: '5',
+          'Median EPAP': '6',
+        },
+      ];
+      if (options.chunk) {
+        options.chunk({ data: rows, meta: { cursor: file.size } });
+      }
+      if (options.complete) {
+        options.complete({ data: rows });
+      }
+    });
+
+    render(<App />);
+
+    const input = screen.getByLabelText(/Summary CSV/i);
+    const file = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {
+      type: 'text/csv',
+    });
+    await userEvent.upload(input, file);
+
+    const printBtn = await screen.findByRole('button', { name: /Print Page/i });
+    expect(printBtn).toBeEnabled();
+    await userEvent.click(printBtn);
+    expect(window.print).toHaveBeenCalled();
+
+    expect(
+      screen.queryByRole('button', { name: /Open Print Report/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/App.toc-active.test.jsx
+++ b/src/App.toc-active.test.jsx
@@ -63,7 +63,7 @@ describe('TOC active highlighting', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('heading', { name: /Overview Dashboard/i })
+        screen.getByRole('heading', { name: /Overview Dashboard/i }),
       ).toBeInTheDocument();
     });
 

--- a/src/App.worker.integration.test.jsx
+++ b/src/App.worker.integration.test.jsx
@@ -42,7 +42,7 @@ describe('Worker Integration Tests', () => {
     // Expect Papa.parse to be called with worker:true
     expect(parseMock).toHaveBeenCalledWith(
       file,
-      expect.objectContaining({ worker: true })
+      expect.objectContaining({ worker: true }),
     );
 
     // Wait for the summary analysis to render

--- a/src/components/AhiTrendsCharts.jsx
+++ b/src/components/AhiTrendsCharts.jsx
@@ -47,7 +47,7 @@ export default function AhiTrendsCharts({
       rolling7,
       rolling30,
       datesArr,
-      0.5
+      0.5,
     );
     const cpDates = detectChangePoints(ahisArr, datesArr, 6);
 
@@ -108,9 +108,9 @@ export default function AhiTrendsCharts({
           else acc.gt30++;
           return acc;
         },
-        { le5: 0, b5_15: 0, b15_30: 0, gt30: 0 }
+        { le5: 0, b5_15: 0, b15_30: 0, gt30: 0 },
       ),
-    [ahis]
+    [ahis],
   );
 
   // QQ-plot against normal
@@ -118,7 +118,7 @@ export default function AhiTrendsCharts({
   const sorted = ahis.slice().sort((a, b) => a - b);
   const mu = sorted.reduce((s, v) => s + v, 0) / n;
   const sigma = Math.sqrt(
-    sorted.reduce((s, v) => s + (v - mu) ** 2, 0) / Math.max(1, n - 1)
+    sorted.reduce((s, v) => s + (v - mu) ** 2, 0) / Math.max(1, n - 1),
   );
   const probs = sorted.map((_, i) => (i + 1) / (n + 1));
   const theo = probs.map((p) => mu + sigma * normalQuantile(p));

--- a/src/components/ApneaClusterAnalysis.jsx
+++ b/src/components/ApneaClusterAnalysis.jsx
@@ -208,12 +208,12 @@ function ApneaClusterAnalysis({ clusters, params, onParamChange, details }) {
                   y: sorted[selected].events.map((_, i) => `Evt ${i + 1}`),
                   x: sorted[selected].events.map((e) => e.durationSec * 1000),
                   base: sorted[selected].events.map((e) =>
-                    e.date.toISOString()
+                    e.date.toISOString(),
                   ),
                   marker: { color: '#ff7f0e' },
                   hovertemplate: sorted[selected].events.map(
                     (e) =>
-                      `${e.date.toLocaleString()}<br>Duration: ${e.durationSec.toFixed(0)} s<extra></extra>`
+                      `${e.date.toLocaleString()}<br>Duration: ${e.durationSec.toFixed(0)} s<extra></extra>`,
                   ),
                 },
               ]}
@@ -224,7 +224,7 @@ function ApneaClusterAnalysis({ clusters, params, onParamChange, details }) {
                 margin: { l: 80, r: 20, t: 40, b: 40 },
                 height: Math.max(
                   200,
-                  sorted[selected].events.length * 30 + 100
+                  sorted[selected].events.length * 30 + 100,
                 ),
               }}
               config={{ displayModeBar: false }}

--- a/src/components/ApneaClusterAnalysis.test.jsx
+++ b/src/components/ApneaClusterAnalysis.test.jsx
@@ -49,12 +49,12 @@ describe('ApneaClusterAnalysis overlay', () => {
         params={params}
         onParamChange={() => {}}
         details={details}
-      />
+      />,
     );
     const rows = screen.getAllByRole('row');
     await userEvent.click(rows[1]);
     expect(
-      await screen.findByText(/Leak\/Pressure around Cluster/)
+      await screen.findByText(/Leak\/Pressure around Cluster/),
     ).toBeInTheDocument();
   });
 });

--- a/src/components/ApneaEventStats.jsx
+++ b/src/components/ApneaEventStats.jsx
@@ -14,7 +14,7 @@ export default function ApneaEventStats() {
   const stats = useMemo(() => computeApneaEventStats(data || []), [data]);
   const km = useMemo(
     () => kmSurvival(stats.durations || []),
-    [stats.durations]
+    [stats.durations],
   );
   if (!stats.totalEvents) {
     return null;

--- a/src/components/ApneaEventStats.test.jsx
+++ b/src/components/ApneaEventStats.test.jsx
@@ -21,7 +21,7 @@ describe('ApneaEventStats', () => {
     const { container } = render(
       <DataProvider filteredDetails={[]}>
         <ApneaEventStats />
-      </DataProvider>
+      </DataProvider>,
     );
     expect(container.firstChild).toBeNull();
   });
@@ -30,7 +30,7 @@ describe('ApneaEventStats', () => {
     const { getAllByTestId, getByText } = render(
       <DataProvider filteredDetails={sampleDetails}>
         <ApneaEventStats />
-      </DataProvider>
+      </DataProvider>,
     );
     expect(getByText('Apnea Event Characteristics')).toBeInTheDocument();
     expect(getByText('Total apnea events')).toBeInTheDocument();

--- a/src/components/DocsModal.test.jsx
+++ b/src/components/DocsModal.test.jsx
@@ -8,13 +8,13 @@ describe('DocsModal', () => {
     const onClose = vi.fn();
     render(<DocsModal isOpen={true} onClose={onClose} />);
     expect(
-      await screen.findByRole('dialog', { name: /usage guide/i })
+      await screen.findByRole('dialog', { name: /usage guide/i }),
     ).toBeInTheDocument();
     expect(
       await screen.findByRole('heading', {
         level: 3,
         name: /Usage & Interpretation Guide/i,
-      })
+      }),
     ).toBeInTheDocument();
   });
 
@@ -24,7 +24,7 @@ describe('DocsModal', () => {
         isOpen={true}
         onClose={() => {}}
         initialAnchor="usage-patterns"
-      />
+      />,
     );
     const headings = await screen.findAllByRole('heading', {
       level: 2,
@@ -36,7 +36,7 @@ describe('DocsModal', () => {
   it('sanitizes malicious markdown', async () => {
     const malicious = `# Hello\n[link](javascript:alert(1))`;
     render(
-      <DocsModal isOpen={true} onClose={() => {}} markdownSource={malicious} />
+      <DocsModal isOpen={true} onClose={() => {}} markdownSource={malicious} />,
     );
     await screen.findByRole('heading', { level: 1, name: /hello/i });
     const link = document.querySelector('.doc-content a');

--- a/src/components/EpapTrendsCharts.jsx
+++ b/src/components/EpapTrendsCharts.jsx
@@ -50,7 +50,7 @@ function EpapTrendsCharts({ data }) {
     const cov =
       epapAhiPairsArr.reduce(
         (sum, p) => sum + (p.epap - meanE) * (p.ahi - meanA),
-        0
+        0,
       ) /
       (n - 1);
     const varE =
@@ -59,7 +59,7 @@ function EpapTrendsCharts({ data }) {
     const stdE = Math.sqrt(varE);
     const stdA = Math.sqrt(
       epapAhiPairsArr.reduce((sum, p) => sum + (p.ahi - meanA) ** 2, 0) /
-        (n - 1)
+        (n - 1),
     );
     const corrVal = cov / (stdE * stdA);
     const slopeVal = cov / varE;
@@ -94,15 +94,15 @@ function EpapTrendsCharts({ data }) {
   }, [epaps]);
   const loess = useMemo(
     () => loessSmooth(epaps, ahis, xs, 0.3),
-    [epaps, ahis, xs]
+    [epaps, ahis, xs],
   );
   const q50 = useMemo(
     () => runningQuantileXY(epaps, ahis, xs, 0.5, 25),
-    [epaps, ahis, xs]
+    [epaps, ahis, xs],
   );
   const q90 = useMemo(
     () => runningQuantileXY(epaps, ahis, xs, 0.9, 25),
-    [epaps, ahis, xs]
+    [epaps, ahis, xs],
   );
 
   const isDark = useEffectiveDarkMode();
@@ -121,7 +121,7 @@ function EpapTrendsCharts({ data }) {
               .split(':')
               .reduce((a, b, i) => a + parseFloat(b) * [3600, 60, 1][i], 0) /
             3600
-          : parseFloat(v)
+          : parseFloat(v),
       )
       .filter((v) => !isNaN(v));
     if (usage.length === epaps.length)
@@ -130,7 +130,7 @@ function EpapTrendsCharts({ data }) {
     const keys = data.length ? Object.keys(data[0]) : [];
     const leakMedKey = keys.find((k) => /leak/i.test(k) && /median/i.test(k));
     const leakPctKey = keys.find(
-      (k) => /leak/i.test(k) && (/%/.test(k) || /time.*above/i.test(k))
+      (k) => /leak/i.test(k) && (/%/.test(k) || /time.*above/i.test(k)),
     );
     let leakMed = null;
     let leakPct = null;
@@ -154,7 +154,7 @@ function EpapTrendsCharts({ data }) {
     }
     const labels = vars.map((v) => v.key);
     const z = labels.map((_, i) =>
-      labels.map((_, j) => pearson(vars[i].values, vars[j].values))
+      labels.map((_, j) => pearson(vars[i].values, vars[j].values)),
     );
     // Partial correlations controlling for Usage and Leak variables if present
     const controlIdx = labels.reduce((arr, k, i) => {
@@ -178,10 +178,10 @@ function EpapTrendsCharts({ data }) {
           return controls[0].length
             ? pearson(
                 olsResidualsFromVars(vars[i].values, controls),
-                olsResidualsFromVars(vars[j].values, controls)
+                olsResidualsFromVars(vars[j].values, controls),
               )
             : z[i][j];
-        })
+        }),
       );
     }
     return { labels, z, zPartial, leakMedKey, leakMed, leakPctKey, leakPct };
@@ -212,7 +212,7 @@ function EpapTrendsCharts({ data }) {
     const inv = (A) => {
       const nn = A.length;
       const M = A.map((row, i) =>
-        row.concat(Array.from({ length: nn }, (_, j) => (i === j ? 1 : 0)))
+        row.concat(Array.from({ length: nn }, (_, j) => (i === j ? 1 : 0))),
       );
       for (let col = 0; col < nn; col++) {
         let pivot = col;
@@ -477,7 +477,7 @@ function EpapTrendsCharts({ data }) {
                   text: isFinite(v) ? v.toFixed(2) : '—',
                   showarrow: false,
                   font: { color: isDark ? '#fff' : '#000' },
-                }))
+                })),
               ),
             }}
             config={{ responsive: true, displaylogo: false }}
@@ -527,7 +527,7 @@ function EpapTrendsCharts({ data }) {
                   text: isFinite(v) ? v.toFixed(2) : '—',
                   showarrow: false,
                   font: { color: isDark ? '#fff' : '#000' },
-                }))
+                })),
               ),
             }}
             config={{ responsive: true, displaylogo: false }}

--- a/src/components/ErrorBoundary.test.jsx
+++ b/src/components/ErrorBoundary.test.jsx
@@ -23,7 +23,7 @@ describe('ErrorBoundary', () => {
     render(
       <ErrorBoundary fallback="fallback text">
         <Bomb />
-      </ErrorBoundary>
+      </ErrorBoundary>,
     );
     expect(screen.getByRole('alert')).toHaveTextContent('fallback text');
   });
@@ -32,7 +32,7 @@ describe('ErrorBoundary', () => {
     render(
       <ErrorBoundary fallback="fallback text">
         <Bomb />
-      </ErrorBoundary>
+      </ErrorBoundary>,
     );
     expect(console.error).toHaveBeenCalled();
   });
@@ -41,7 +41,7 @@ describe('ErrorBoundary', () => {
     render(
       <ErrorBoundary fallback="fallback text">
         <Okay />
-      </ErrorBoundary>
+      </ErrorBoundary>,
     );
     expect(screen.getByText('ok')).toBeInTheDocument();
   });

--- a/src/components/FalseNegativesAnalysis.jsx
+++ b/src/components/FalseNegativesAnalysis.jsx
@@ -51,7 +51,7 @@ function FalseNegativesAnalysis({ list, preset, onPresetChange }) {
                 y: list.map((cl) => cl.confidence * 100),
                 marker: {
                   size: list.map((cl) =>
-                    Math.max(6, Math.min(20, Math.sqrt(cl.durationSec) * 5))
+                    Math.max(6, Math.min(20, Math.sqrt(cl.durationSec) * 5)),
                   ),
                   color: list.map((cl) => cl.confidence * 100),
                   colorscale: 'Viridis',
@@ -60,7 +60,7 @@ function FalseNegativesAnalysis({ list, preset, onPresetChange }) {
                 },
                 text: list.map(
                   (cl) =>
-                    `Start: ${cl.start.toLocaleString()}<br>Duration: ${cl.durationSec.toFixed(0)} s<br>Confidence: ${(cl.confidence * 100).toFixed(0)}%`
+                    `Start: ${cl.start.toLocaleString()}<br>Duration: ${cl.durationSec.toFixed(0)} s<br>Confidence: ${(cl.confidence * 100).toFixed(0)}%`,
                 ),
                 hovertemplate: '%{text}<extra></extra>',
               },

--- a/src/components/FalseNegativesAnalysis.test.jsx
+++ b/src/components/FalseNegativesAnalysis.test.jsx
@@ -19,7 +19,7 @@ describe('FalseNegativesAnalysis', () => {
         list={sample}
         preset="balanced"
         onPresetChange={onChange}
-      />
+      />,
     );
     const select = screen.getByLabelText(/preset/i);
     fireEvent.change(select, { target: { value: 'strict' } });

--- a/src/components/KPICard.test.jsx
+++ b/src/components/KPICard.test.jsx
@@ -7,7 +7,7 @@ describe('KPICard', () => {
     const { asFragment } = render(
       <KPICard title="Test KPI" value="42">
         <span data-testid="child">Child Content</span>
-      </KPICard>
+      </KPICard>,
     );
     expect(screen.getByText('Test KPI')).toBeInTheDocument();
     expect(screen.getByText('42')).toBeInTheDocument();

--- a/src/components/Overview.test.jsx
+++ b/src/components/Overview.test.jsx
@@ -25,7 +25,7 @@ describe('Overview', () => {
     render(
       <DataProvider summaryData={summaryData} filteredSummary={summaryData}>
         <Overview clusters={clusters} falseNegatives={falseNegatives} />
-      </DataProvider>
+      </DataProvider>,
     );
     expect(screen.getByText('Overview Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Avg Usage (hrs)')).toBeInTheDocument();

--- a/src/components/RangeComparisons.jsx
+++ b/src/components/RangeComparisons.jsx
@@ -24,7 +24,7 @@ export default function RangeComparisons({ rangeA, rangeB }) {
         return (!r.start || d >= r.start) && (!r.end || d <= r.end);
       });
     },
-    [summaryData]
+    [summaryData],
   );
   const A = useMemo(() => pick(rangeA), [pick, rangeA]);
   const B = useMemo(() => pick(rangeB), [pick, rangeB]);

--- a/src/components/RangeComparisons.test.jsx
+++ b/src/components/RangeComparisons.test.jsx
@@ -15,10 +15,16 @@ describe('RangeComparisons', () => {
     render(
       <DataProvider summaryData={summary}>
         <RangeComparisons
-          rangeA={{ start: new Date('2024-01-01'), end: new Date('2024-01-10') }}
-          rangeB={{ start: new Date('2024-02-01'), end: new Date('2024-02-10') }}
+          rangeA={{
+            start: new Date('2024-01-01'),
+            end: new Date('2024-01-10'),
+          }}
+          rangeB={{
+            start: new Date('2024-02-01'),
+            end: new Date('2024-02-10'),
+          }}
         />
-      </DataProvider>
+      </DataProvider>,
     );
     expect(screen.getByText(/Range Comparisons/)).toBeInTheDocument();
     expect(screen.getByText(/Usage/)).toBeInTheDocument();

--- a/src/components/RawDataExplorer.jsx
+++ b/src/components/RawDataExplorer.jsx
@@ -94,7 +94,7 @@ export default function RawDataExplorer({ onApplyDateFilter }) {
 
   const toggleCol = (c) => {
     setVisibleCols((prev) =>
-      prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]
+      prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c],
     );
   };
 
@@ -378,7 +378,7 @@ export default function RawDataExplorer({ onApplyDateFilter }) {
                           >
                             {String(row?.[c] ?? '')}
                           </div>
-                        )
+                        ),
                       )}
                     </div>
                   )}

--- a/src/components/RawDataExplorer.test.jsx
+++ b/src/components/RawDataExplorer.test.jsx
@@ -27,7 +27,7 @@ describe('RawDataExplorer', () => {
     render(
       <DataProvider summaryData={sampleSummary} detailsData={sampleDetails}>
         <RawDataExplorer />
-      </DataProvider>
+      </DataProvider>,
     );
     expect(screen.getByRole('tablist')).toBeInTheDocument();
     // Table should show 3 rows initially (reported count)
@@ -41,7 +41,7 @@ describe('RawDataExplorer', () => {
     render(
       <DataProvider summaryData={sampleSummary} detailsData={sampleDetails}>
         <RawDataExplorer />
-      </DataProvider>
+      </DataProvider>,
     );
     const summary = screen.getByText('Columns');
     await userEvent.click(summary);
@@ -50,7 +50,7 @@ describe('RawDataExplorer', () => {
     await userEvent.click(ahiToggle);
     // Column header should no longer include AHI
     expect(
-      screen.queryByRole('columnheader', { name: /AHI/ })
+      screen.queryByRole('columnheader', { name: /AHI/ }),
     ).not.toBeInTheDocument();
   });
 
@@ -58,7 +58,7 @@ describe('RawDataExplorer', () => {
     render(
       <DataProvider summaryData={sampleSummary} detailsData={sampleDetails}>
         <RawDataExplorer />
-      </DataProvider>
+      </DataProvider>,
     );
     // Click AHI header to sort asc
     const ahiHeader = await screen.findByRole('columnheader', { name: 'AHI' });
@@ -76,14 +76,14 @@ describe('RawDataExplorer', () => {
     render(
       <DataProvider summaryData={sampleSummary} detailsData={sampleDetails}>
         <RawDataExplorer onApplyDateFilter={onApply} />
-      </DataProvider>
+      </DataProvider>,
     );
     const start = screen.getByLabelText('Start date:');
     const end = screen.getByLabelText('End date:');
     await userEvent.type(start, '2024-07-02');
     await userEvent.type(end, '2024-07-03');
     await userEvent.click(
-      screen.getByRole('button', { name: /Apply to charts/i })
+      screen.getByRole('button', { name: /Apply to charts/i }),
     );
     expect(onApply).toHaveBeenCalledTimes(1);
     const arg = onApply.mock.calls[0][0];

--- a/src/components/SummaryAnalysis.test.jsx
+++ b/src/components/SummaryAnalysis.test.jsx
@@ -25,7 +25,7 @@ describe('SummaryAnalysis', () => {
     render(
       <DataProvider summaryData={sample} filteredSummary={sample}>
         <SummaryAnalysis />
-      </DataProvider>
+      </DataProvider>,
     );
     expect(UsagePatternsCharts.mock.calls[0][0].onRangeSelect).toBeUndefined();
     expect(AhiTrendsCharts.mock.calls[0][0].onRangeSelect).toBeUndefined();

--- a/src/components/ThemeToggle.test.jsx
+++ b/src/components/ThemeToggle.test.jsx
@@ -15,7 +15,7 @@ describe('ThemeToggle', () => {
     render(
       <DataProvider>
         <ThemeToggle />
-      </DataProvider>
+      </DataProvider>,
     );
     expect(document.documentElement.getAttribute('data-theme')).toBe(null);
     const group = screen.getByRole('group', { name: /theme/i });
@@ -31,7 +31,7 @@ describe('ThemeToggle', () => {
     render(
       <DataProvider>
         <ThemeToggle />
-      </DataProvider>
+      </DataProvider>,
     );
     const dark = screen.getByRole('radio', { name: /dark/i });
     await user.click(dark);
@@ -44,7 +44,7 @@ describe('ThemeToggle', () => {
     render(
       <DataProvider>
         <ThemeToggle />
-      </DataProvider>
+      </DataProvider>,
     );
     const light = screen.getByRole('radio', { name: /light/i });
     const system = screen.getByRole('radio', { name: /system/i });

--- a/src/components/UsagePatternsCharts.jsx
+++ b/src/components/UsagePatternsCharts.jsx
@@ -91,7 +91,7 @@ function UsagePatternsCharts({ data, onRangeSelect }) {
             d.setDate(d.getDate() + dowIdx);
             const key = dateToStr(toISODate(d));
             return byDate.has(key) ? byDate.get(key) : null;
-          })
+          }),
         )
       : yLabels.map(() => []);
     const dowHeatmap = { x: weekStarts, y: yLabels, z };
@@ -133,7 +133,7 @@ function UsagePatternsCharts({ data, onRangeSelect }) {
         onRangeSelect({ start: new Date(x0), end: new Date(x1) });
       }
     },
-    [onRangeSelect]
+    [onRangeSelect],
   );
 
   return (

--- a/src/context/DataContext.jsx
+++ b/src/context/DataContext.jsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 export const THEMES = {
   SYSTEM: 'system',
@@ -56,7 +62,7 @@ export function DataProvider({
       filteredSummary,
       filteredDetails,
       theme,
-    ]
+    ],
   );
 
   return <DataContext.Provider value={value}>{children}</DataContext.Provider>;
@@ -74,4 +80,3 @@ export function useTheme() {
 }
 
 export default DataContext;
-

--- a/src/context/DataContext.test.jsx
+++ b/src/context/DataContext.test.jsx
@@ -23,7 +23,7 @@ describe('DataContext provider', () => {
     render(
       <ErrorBoundary fallback="context error">
         <Consumer />
-      </ErrorBoundary>
+      </ErrorBoundary>,
     );
     expect(screen.getByRole('alert')).toHaveTextContent('context error');
   });
@@ -33,10 +33,10 @@ describe('DataContext provider', () => {
     render(
       <DataProvider>
         <div>child</div>
-      </DataProvider>
+      </DataProvider>,
     );
     expect(document.documentElement.getAttribute('data-theme')).toBe(
-      THEMES.DARK
+      THEMES.DARK,
     );
   });
 

--- a/src/hooks/useCsvFiles.js
+++ b/src/hooks/useCsvFiles.js
@@ -83,7 +83,7 @@ export function useCsvFiles() {
         setSummaryData,
         setLoadingSummary,
         setSummaryProgress,
-        setSummaryProgressMax
+        setSummaryProgressMax,
       )(e);
     },
     onDetailsFile: handleFile(
@@ -91,7 +91,7 @@ export function useCsvFiles() {
       setLoadingDetails,
       setDetailsProgress,
       setDetailsProgressMax,
-      true /* filter to only apnea & FLG events */
+      true /* filter to only apnea & FLG events */,
     ),
   };
 }

--- a/src/hooks/usePrefersDarkMode.js
+++ b/src/hooks/usePrefersDarkMode.js
@@ -8,7 +8,7 @@ export function usePrefersDarkMode() {
   const [isDark, setIsDark] = useState(
     typeof window !== 'undefined' &&
       window.matchMedia &&
-      window.matchMedia('(prefers-color-scheme: dark)').matches
+      window.matchMedia('(prefers-color-scheme: dark)').matches,
   );
   useEffect(() => {
     if (!window.matchMedia) return;

--- a/src/hooks/useSessionManager.test.js
+++ b/src/hooks/useSessionManager.test.js
@@ -46,7 +46,7 @@ describe('useSessionManager', () => {
         setRangeB: vi.fn(),
         setSummaryData: vi.fn(),
         setDetailsData: vi.fn(),
-      })
+      }),
     );
     act(() => result.current.setPersistEnabled(true));
     vi.advanceTimersByTime(600);
@@ -76,7 +76,7 @@ describe('useSessionManager', () => {
         setRangeB: vi.fn(),
         setSummaryData: vi.fn(),
         setDetailsData: vi.fn(),
-      })
+      }),
     );
     vi.advanceTimersByTime(600);
     const { putLastSession } = await import('../utils/db');
@@ -105,7 +105,7 @@ describe('useSessionManager', () => {
         setRangeB: vi.fn(),
         setSummaryData,
         setDetailsData: vi.fn(),
-      })
+      }),
     );
     await act(async () => {
       await result.current.handleLoadSaved();
@@ -131,7 +131,7 @@ describe('useSessionManager', () => {
         setRangeB: vi.fn(),
         setSummaryData: vi.fn(),
         setDetailsData: vi.fn(),
-      })
+      }),
     );
     act(() => result.current.setPersistEnabled(true));
     vi.advanceTimersByTime(600);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -14,5 +14,5 @@ root.render(
     <ErrorBoundary>
       <App />
     </ErrorBoundary>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -4,7 +4,7 @@ import { vi } from 'vitest';
 
 // Mock Plotly charts to simplify component tests
 const plotlyMock = vi.fn((props) =>
-  React.createElement('div', { 'data-testid': 'plotly-chart', ...props })
+  React.createElement('div', { 'data-testid': 'plotly-chart', ...props }),
 );
 vi.mock('react-plotly.js', () => {
   return { default: plotlyMock };

--- a/src/utils/clustering.js
+++ b/src/utils/clustering.js
@@ -37,7 +37,7 @@ export function clusterApneaEvents(
   edgeEnter = EDGE_THRESHOLD,
   edgeExit = EDGE_THRESHOLD * EDGE_EXIT_FRACTION,
   edgeMinDurSec = EDGE_MIN_DURATION_SEC,
-  minDensityPerMin = 0
+  minDensityPerMin = 0,
 ) {
   if (!events.length) return [];
   // FLG clusters for bridging annotation gaps (lower threshold)
@@ -108,16 +108,16 @@ export function clusterApneaEvents(
     let end = new Date(lastEvt.date.getTime() + lastEvt.durationSec * 1000);
     const count = group.length;
     const validEdges = flgEdgeSegments.filter(
-      (cl) => (cl[cl.length - 1].date - cl[0].date) / 1000 >= edgeMinDurSec
+      (cl) => (cl[cl.length - 1].date - cl[0].date) / 1000 >= edgeMinDurSec,
     );
     const before = validEdges.find(
       (cl) =>
         cl[cl.length - 1].date <= start &&
-        (start - cl[cl.length - 1].date) / 1000 <= gapSec
+        (start - cl[cl.length - 1].date) / 1000 <= gapSec,
     );
     if (before) start = before[0].date;
     const after = validEdges.find(
-      (cl) => cl[0].date >= end && (cl[0].date - end) / 1000 <= gapSec
+      (cl) => cl[0].date >= end && (cl[0].date - end) / 1000 <= gapSec,
     );
     if (after) end = after[after.length - 1].date;
     const durationSec = (end - start) / 1000;
@@ -126,7 +126,7 @@ export function clusterApneaEvents(
   });
   // Optional density filter
   return clusters.filter((cl) =>
-    minDensityPerMin ? cl.density >= minDensityPerMin : true
+    minDensityPerMin ? cl.density >= minDensityPerMin : true,
   );
 }
 
@@ -176,7 +176,7 @@ export function detectFalseNegatives(details, opts = {}) {
     })
     .filter(
       (cl) =>
-        cl.durationSec >= minDurationSec && cl.durationSec <= maxDurationSec
+        cl.durationSec >= minDurationSec && cl.durationSec <= maxDurationSec,
     )
     .filter((cl) => {
       // no known apnea events within expanded window
@@ -216,12 +216,12 @@ export function computeClusterSeverity(cluster) {
   if (!cluster || !cluster.events?.length) return 0;
   const totalEvtDuration = cluster.events.reduce(
     (s, e) => s + (e.durationSec || 0),
-    0
+    0,
   );
   const firstStart = cluster.events[0].date;
   const lastEvt = cluster.events[cluster.events.length - 1];
   const lastEnd = new Date(
-    lastEvt.date.getTime() + (lastEvt.durationSec || 0) * 1000
+    lastEvt.date.getTime() + (lastEvt.durationSec || 0) * 1000,
   );
   const rawSpanSec = Math.max(1, (lastEnd - firstStart) / 1000);
   const windowMin = Math.max(1 / 60, cluster.durationSec / 60);

--- a/src/utils/clustering.test.js
+++ b/src/utils/clustering.test.js
@@ -43,7 +43,7 @@ describe('clusterApneaEvents', () => {
       0.5,
       0.35,
       10,
-      1.5
+      1.5,
     );
     // density = 2 events over ~3+ minutes -> < 1.5 ev/min, so filtered out
     expect(clusters.length).toBe(0);
@@ -69,7 +69,7 @@ describe('clusterApneaEvents', () => {
       0.5,
       0.35,
       5,
-      0
+      0,
     );
     expect(clusters.length).toBe(1);
     // start should be extended back to first FLG in edge segment (30s)
@@ -157,7 +157,7 @@ describe('computeClusterSeverity', () => {
         [30, 10],
       ],
       0,
-      60
+      60,
     ); // extension -> higher
     expect(s2).toBeGreaterThan(s1);
     expect(s3).toBeGreaterThan(s1);

--- a/src/utils/export.js
+++ b/src/utils/export.js
@@ -42,52 +42,6 @@ export function downloadTextFile(name, content, type = 'text/plain') {
   URL.revokeObjectURL(url);
 }
 
-export function openPrintReportHTML(
-  summaryData = [],
-  clusters = [],
-  falseNegatives = []
-) {
-  const usage = summarizeUsage(summaryData || []);
-  const ahi = computeAHITrends(summaryData || []);
-  const epap = computeEPAPTrends(summaryData || []);
-  const html = `<!doctype html><html><head><meta charset="utf-8"/><title>OSCAR Report</title>
-    <style>
-      body{font-family:system-ui, -apple-system, Segoe UI, Roboto, sans-serif; padding: 16px; color:#111}
-      h1,h2{margin: 0 0 8px}
-      table{width:100%;border-collapse:collapse;margin:12px 0}
-      th,td{border:1px solid #ccc;padding:6px 8px;text-align:left}
-      .muted{opacity:.8}
-    </style>
-  </head><body>
-    <h1>OSCAR Sleep Data Report</h1>
-    <p class="muted">Generated ${new Date().toLocaleString()}</p>
-    <h2>Usage</h2>
-    <table><tbody>
-      <tr><td>Total nights</td><td>${usage.totalNights}</td></tr>
-      <tr><td>Avg hours</td><td>${round(usage.avgHours, 2)}</td></tr>
-      <tr><td>Median hours</td><td>${round(usage.medianHours, 2)}</td></tr>
-      <tr><td>% nights ≥4h</td><td>${round((usage.nightsLong / usage.totalNights) * 100, 1)}%</td></tr>
-    </tbody></table>
-    <h2>AHI</h2>
-    <table><tbody>
-      <tr><td>Average</td><td>${round(ahi.avgAHI, 2)}</td></tr>
-      <tr><td>Median</td><td>${round(ahi.medianAHI, 2)}</td></tr>
-      <tr><td>Min / Max</td><td>${round(ahi.minAHI, 2)} / ${round(ahi.maxAHI, 2)}</td></tr>
-    </tbody></table>
-    <h2>EPAP</h2>
-    <table><tbody>
-      <tr><td>Median</td><td>${round(epap.medianEPAP, 2)}</td></tr>
-      <tr><td>IQR</td><td>${round(epap.p25EPAP, 2)}–${round(epap.p75EPAP, 2)}</td></tr>
-    </tbody></table>
-    <h2>Clusters & False Negatives</h2>
-    <p>Clusters: ${clusters.length}; False negatives: ${falseNegatives.length}</p>
-    <script>window.print&&setTimeout(()=>window.print(),300)</script>
-  </body></html>`;
-  const blob = new Blob([html], { type: 'text/html;charset=utf-8' });
-  const url = URL.createObjectURL(blob);
-  window.open(url, '_blank');
-}
-
 function round(v, d) {
   return Number.isFinite(v) ? Number(v).toFixed(d) : '—';
 }

--- a/src/workers/analytics.worker.js
+++ b/src/workers/analytics.worker.js
@@ -12,7 +12,7 @@ self.onmessage = (e) => {
     try {
       const apneaEvents = detailsData
         .filter((r) =>
-          ['ClearAirway', 'Obstructive', 'Mixed'].includes(r['Event'])
+          ['ClearAirway', 'Obstructive', 'Mixed'].includes(r['Event']),
         )
         .map((r) => ({
           date: new Date(r['DateTime']),
@@ -33,7 +33,7 @@ self.onmessage = (e) => {
         params.edgeEnter,
         params.edgeExit,
         10,
-        params.minDensity
+        params.minDensity,
       );
       const fns = detectFalseNegatives(detailsData, fnOptions || {});
       self.postMessage({

--- a/styles.css
+++ b/styles.css
@@ -541,3 +541,16 @@ select:focus-visible {
   outline: 2px solid color-mix(in oklab, var(--color-accent) 40%, transparent);
   outline-offset: 2px;
 }
+/* Print styles */
+@media print {
+  .app-header,
+  .btn-primary,
+  .btn-ghost,
+  .guide-link,
+  .guide-inline,
+  button,
+  input,
+  select {
+    display: none !important;
+  }
+}

--- a/styles.print.test.js
+++ b/styles.print.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('print styles', () => {
+  const css = fs.readFileSync(path.join(process.cwd(), 'styles.css'), 'utf8');
+  it('includes print media query', () => {
+    expect(css).toMatch(/@media print/);
+  });
+  it('hides header and interactive elements', () => {
+    expect(css).toMatch(
+      /@media print[\s\S]*\.app-header[\s\S]*display:\s*none/,
+    );
+    expect(css).toMatch(
+      /@media print[\s\S]*\.btn-primary[\s\S]*display:\s*none/,
+    );
+    expect(css).toMatch(
+      /@media print[\s\S]*(\.guide-link|\.guide-inline)[\s\S]*display:\s*none/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- hide headers and interactive controls in print media queries
- add Print Page button replacing legacy report export
- document printing workflow in FAQ and visualization docs
- cover print button and styles in tests

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0dccb8348832f84b69c32eaa6f8c3