### PR TITLE
chore: configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'chore'
+      prefix-development: 'chore'
+      include: 'scope'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'chore'
+      prefix-development: 'chore'
+      include: 'scope'

--- a/README.md
+++ b/README.md
@@ -108,8 +108,6 @@ npm test -- --run
 npm run build
 ```
 
-Dependabot monitors npm packages and GitHub Actions workflows, opening pull requests to keep dependencies up to date.
-
 Production builds are deployed to GitHub Pages. Pushes to `main` update the live site, while approved pull requests trigger temporary preview deployments via `.github/workflows/pages.yml`. After approving a PR, authorize the `pr-preview` environment to publish the preview.
 
 See the [Developer Guide](docs/developer/README.md) for testing patterns and architectural notes.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ npm test -- --run
 npm run build
 ```
 
+Dependabot monitors npm packages and GitHub Actions workflows, opening pull requests to keep dependencies up to date.
+
 Production builds are deployed to GitHub Pages. Pushes to `main` update the live site, while approved pull requests trigger temporary preview deployments via `.github/workflows/pages.yml`. After approving a PR, authorize the `pr-preview` environment to publish the preview.
 
 See the [Developer Guide](docs/developer/README.md) for testing patterns and architectural notes.


### PR DESCRIPTION
## Summary
- add Dependabot config for npm packages and GitHub Actions
- document automatic dependency updates in README

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0f921ad68832fa8d699dbd900ea63