### PR TITLE
chore(ci): restrict workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- reduce default token privileges in CI workflow

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c100480a54832f923244bd40890105