### PR TITLE
chore: ignore Vite stats report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 coverage/
+stats.html
 *.log
 data/
 .env

--- a/docs/developer/setup.md
+++ b/docs/developer/setup.md
@@ -66,7 +66,7 @@ Create a production bundle with:
 npm run build
 ```
 
-The output lands in the `dist/` directory. To inspect the production build locally, run:
+The output lands in the `dist/` directory. The build also generates a `stats.html` bundle report in the project root via Vite's visualizer plugin; open it in a browser to inspect module sizes. The file is git-ignored. To inspect the production build locally, run:
 
 ```bash
 npm run preview


### PR DESCRIPTION
## Summary
- ignore `stats.html` produced by Vite's bundle visualizer
- note the `stats.html` report in developer build instructions

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c19388357c832f8aee5bbf0f4bb45a