### PR TITLE
feat: refine header layout with date filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ If `BASE_URL` is unset, the build defaults to `/oscar-export-analyzer/`.
 2. In the analyzer, use the **Summary CSV** picker to load the nightly summary file.
 3. Optionally load the **Details CSV** to unlock cluster detection and false‑negative analysis.
 4. Navigate via the sidebar to explore dashboards: **Overview**, **Usage Patterns**, **AHI Trends**, and more.
-5. Hover any chart element for a tooltip. Click legend items to toggle series visibility. Use the zoom controls to focus on ranges of interest.
-6. Enable **Remember data locally** if you want sessions to persist after closing the tab. Uploading a new Summary CSV replaces any previous session, and data is only saved after a file has been loaded so a refresh with no files won't wipe prior data. Use **Export JSON** to save a portable session snapshot.
+5. Use the date range filter in the header to limit which nights are included across all views.
+6. Hover any chart element for a tooltip. Click legend items to toggle series visibility. Use the zoom controls to focus on ranges of interest.
+7. Enable **Remember data locally** if you want sessions to persist after closing the tab. Uploading a new Summary CSV replaces any previous session, and data is only saved after a file has been loaded so a refresh with no files won't wipe prior data. Use **Export JSON** to save a portable session snapshot.
 
 ## Feature Tour
 

--- a/docs/user/01-getting-started.md
+++ b/docs/user/01-getting-started.md
@@ -54,7 +54,7 @@ The application is organized into several views accessible from the sidebar:
 - **Event Analysis** – Includes apnea duration distributions, cluster detection, and potential false negatives.
 - **Raw Data** – Tabular view of the CSV contents with filtering and export.
 
-Use the theme toggle in the header to switch between light, dark, or system themes. The interface responds to window resizing and touch input for tablets.
+Use the theme toggle in the header to switch between light, dark, or system themes. A global date range filter beside the title narrows which nights are included in every view. The interface responds to window resizing and touch input for tablets.
 
 ## 4. Saving and Restoring Sessions
 

--- a/src/App.header-date-filter.test.jsx
+++ b/src/App.header-date-filter.test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+describe('Header date filter', () => {
+  it('renders date inputs inside the header', () => {
+    render(<App />);
+    const startInput = screen.getByLabelText(/start date/i);
+    const endInput = screen.getByLabelText(/end date/i);
+    const header = startInput.closest('header');
+    expect(header).toHaveClass('app-header');
+    expect(endInput.closest('header')).toBe(header);
+  });
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -362,6 +362,13 @@ function App() {
     // Re-run when data presence changes which may mount/unmount sections
   }, [filteredSummary, filteredDetails, tocSections]);
 
+  const formatDate = (d) =>
+    d
+      ? new Date(d.getTime() - d.getTimezoneOffset() * 60000)
+          .toISOString()
+          .slice(0, 10)
+      : '';
+
   return (
     <DataProvider
       summaryData={summaryData}
@@ -371,24 +378,59 @@ function App() {
       filteredSummary={filteredSummary}
       filteredDetails={filteredDetails}
     >
-      <div className="container">
-        <header className="app-header">
-          <div className="inner">
-            <div className="title">
-              <h1>OSCAR Sleep Data Analysis</h1>
-              <span className="badge">beta</span>
-            </div>
+      <header className="app-header">
+        <div className="inner">
+          <div className="title">
+            <h1>OSCAR Sleep Data Analysis</h1>
+            <span className="badge">beta</span>
+          </div>
+          <div className="date-filter">
+            <input
+              type="date"
+              value={formatDate(dateFilter.start)}
+              onChange={(e) =>
+                setDateFilter((prev) => ({
+                  ...prev,
+                  start: e.target.value ? new Date(e.target.value) : null,
+                }))
+              }
+              aria-label="Start date"
+            />
+            <span>-</span>
+            <input
+              type="date"
+              value={formatDate(dateFilter.end)}
+              onChange={(e) =>
+                setDateFilter((prev) => ({
+                  ...prev,
+                  end: e.target.value ? new Date(e.target.value) : null,
+                }))
+              }
+              aria-label="End date"
+            />
+            {(dateFilter.start || dateFilter.end) && (
+              <button
+                className="btn-ghost"
+                onClick={() => setDateFilter({ start: null, end: null })}
+                aria-label="Reset date filter"
+              >
+                ×
+              </button>
+            )}
+          </div>
+          <div className="actions">
             <ThemeToggle />
             <button
               className="btn-ghost"
-              style={{ marginLeft: 8 }}
               onClick={openGuideForActive}
               aria-label="Open Usage Guide"
             >
               Guide
             </button>
           </div>
-        </header>
+        </div>
+      </header>
+      <div className="container">
         <nav className="toc">
           {tocSections.map((s) => (
             <a
@@ -500,46 +542,6 @@ function App() {
               disabled={!summaryData}
             >
               Print Page
-            </button>
-          </div>
-          <div
-            style={{
-              display: 'flex',
-              flexWrap: 'wrap',
-              gap: 8,
-              alignItems: 'end',
-            }}
-          >
-            <div>
-              <label>
-                Filter start{' '}
-                <input
-                  type="date"
-                  onChange={(e) =>
-                    setDateFilter((prev) => ({
-                      ...prev,
-                      start: e.target.value ? new Date(e.target.value) : null,
-                    }))
-                  }
-                />
-              </label>
-            </div>
-            <div>
-              <label>
-                Filter end{' '}
-                <input
-                  type="date"
-                  onChange={(e) =>
-                    setDateFilter((prev) => ({
-                      ...prev,
-                      end: e.target.value ? new Date(e.target.value) : null,
-                    }))
-                  }
-                />
-              </label>
-            </div>
-            <button onClick={() => setDateFilter({ start: null, end: null })}>
-              Reset filter
             </button>
           </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -120,10 +120,13 @@ h1 {
   box-shadow: var(--shadow-1);
 }
 .app-header .inner {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
-  padding: 10px 0;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 10px 16px;
+  gap: 12px;
 }
 .app-header .title {
   display: flex;
@@ -137,6 +140,24 @@ h1 {
   background: var(--color-kpi-bg);
   color: var(--color-text-muted);
   border: 1px solid var(--color-border-light);
+}
+.app-header .date-filter {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  justify-self: center;
+}
+.app-header .date-filter input {
+  padding: 2px 4px;
+}
+.app-header .date-filter button {
+  padding: 2px 6px;
+}
+.app-header .actions {
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 /* Theme toggle */


### PR DESCRIPTION
## Summary
- move global date range filter into header with compact inputs
- expand header to full width and align actions at the right
- document header filter and add regression test

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1a5143e2c832f83ca553589faa3a0