### PR TITLE
feat: stream parsed CSV rows via worker

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -9,8 +9,8 @@ framework abstractions. This section peels back the layers so you can orient you
 1. **Entry Point** – `main.jsx` bootstraps the React app and mounts `<App />` inside a root DOM node. Vite handles module
    loading and hot replacement during development.
 2. **File Upload** – The top portion of `App.jsx` exposes two file inputs for summary and details CSV exports. When a
-   file is chosen, the `useSessionManager` hook spins up a web worker to parse the file with PapaParse. Progress is
-   reported back to the UI through `postMessage` events.
+   file is chosen, a dedicated parser worker filters events, converts timestamps, and streams batches via `postMessage`
+   so the main thread receives only necessary data.
 3. **Context Store** – Parsed rows and application settings live in `DataContext`. Components consume these values via
    hooks like `useData`, `useParameters`, and `useTheme`. Using context keeps props shallow and makes it easy to expose
    new pieces of state without threading them through every component.

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -10,7 +10,8 @@ framework abstractions. This section peels back the layers so you can orient you
    loading and hot replacement during development.
 2. **File Upload** – The top portion of `App.jsx` exposes two file inputs for summary and details CSV exports. When a
    file is chosen, a dedicated parser worker filters events, converts timestamps, and streams batches via `postMessage`
-   so the main thread receives only necessary data.
+   so the main thread receives only necessary data. Analysis sections render only after at least one row arrives,
+   preventing charts from initializing with empty data.
 3. **Context Store** – Parsed rows and application settings live in `DataContext`. Components consume these values via
    hooks like `useData`, `useParameters`, and `useTheme`. Using context keeps props shallow and makes it easy to expose
    new pieces of state without threading them through every component.

--- a/docs/user/01-getting-started.md
+++ b/docs/user/01-getting-started.md
@@ -33,14 +33,14 @@ The details export provides higher fidelity information:
 
 1. Open <http://localhost:5173> after starting the development server or the deployed site if using a prebuilt bundle.
 2. Use the **Summary CSV** file input to choose the exported summary file.
-3. Optionally choose the **Details CSV** file. Large files are parsed in a background worker and show progress bars.
+3. Optionally choose the **Details CSV** file. A background worker filters events and streams batches with progress updates so even huge files remain responsive.
 4. Once loaded, the sidebar links become active and charts render automatically.
 
 ![File pickers with summary and details loaded](../images/getting-started-upload.png)
 
 ### Handling Large Files
 
-The parser streams rows so even multi‑year exports load gradually. A counter displays how many rows have been processed and when parsing is complete. If memory becomes an issue, consider trimming your export to a smaller date range.
+The parser streams only the necessary rows and converts timestamps inside the worker. A counter displays how many rows have been processed and when parsing is complete. If memory becomes an issue, consider trimming your export to a smaller date range.
 
 ## 3. Navigating the Interface
 

--- a/src/App.csv-upload.test.jsx
+++ b/src/App.csv-upload.test.jsx
@@ -1,45 +1,12 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import Papa from 'papaparse';
 import App from './App';
 
 // Tests cross-component behavior triggered by CSV uploads
 
 describe('CSV uploads and cross-component interactions', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('shows overview after summary upload and raw data explorer after details upload', async () => {
-    const parseMock = vi
-      .spyOn(Papa, 'parse')
-      .mockImplementation((file, options) => {
-        const isSummary = file.name.includes('summary');
-        const rows = isSummary
-          ? [
-              {
-                Date: '2025-06-01',
-                'Total Time': '08:00:00',
-                AHI: '5',
-                'Median EPAP': '6',
-              },
-            ]
-          : [
-              {
-                Event: 'ClearAirway',
-                DateTime: '2025-06-01T00:00:00',
-                'Data/Duration': '12',
-              },
-            ];
-        if (options.chunk) {
-          options.chunk({ data: rows, meta: { cursor: file.size } });
-        }
-        if (options.complete) {
-          options.complete({ data: rows });
-        }
-      });
-
     render(<App />);
 
     const summaryInput = screen.getByLabelText(/Summary CSV/i);
@@ -71,17 +38,6 @@ describe('CSV uploads and cross-component interactions', () => {
       ).toBeInTheDocument();
     });
 
-    // Ensure Papa.parse ran for both files using workers
-    expect(parseMock).toHaveBeenCalledTimes(2);
-    expect(parseMock).toHaveBeenNthCalledWith(
-      1,
-      summaryFile,
-      expect.objectContaining({ worker: true }),
-    );
-    expect(parseMock).toHaveBeenNthCalledWith(
-      2,
-      detailsFile,
-      expect.objectContaining({ worker: true }),
-    );
+    // Default worker stub handles parsing; reaching here implies workers executed
   });
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -551,7 +551,7 @@ function App() {
             </button>
           </div>
         </div>
-        {filteredSummary && (
+        {filteredSummary?.length > 0 && (
           <div className="section">
             <Overview
               clusters={apneaClusters}
@@ -559,7 +559,7 @@ function App() {
             />
           </div>
         )}
-        {filteredSummary && (
+        {filteredSummary?.length > 0 && (
           <div className="section">
             <ErrorBoundary>
               <Suspense fallback={<div>Loading...</div>}>
@@ -653,7 +653,7 @@ function App() {
             </div>
           </div>
         )}
-        {filteredDetails && (
+        {filteredDetails?.length > 0 && (
           <>
             <div className="section">
               <ErrorBoundary>

--- a/src/App.navigation.test.jsx
+++ b/src/App.navigation.test.jsx
@@ -1,68 +1,35 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import Papa from 'papaparse';
 import App from './App';
 
 describe('In-page navigation', () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    // Reset hash between tests
     window.location.hash = '';
   });
 
   it('renders Overview with only Summary CSV and updates hash on click', async () => {
-    const parseMock = vi
-      .spyOn(Papa, 'parse')
-      .mockImplementation((file, options) => {
-        // Simulate parsing a minimal Summary row
-        const rows = [
-          {
-            Date: '2025-06-01',
-            'Total Time': '08:00:00',
-            AHI: '5',
-            'Median EPAP': '6',
-          },
-        ];
-        if (options.chunk) {
-          options.chunk({ data: rows, meta: { cursor: file.size } });
-        }
-        if (options.complete) {
-          options.complete({ data: rows });
-        }
-      });
-
     render(<App />);
 
-    // Upload only the Summary CSV
     const input = screen.getByLabelText(/Summary CSV/i);
     const file = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {
       type: 'text/csv',
     });
     await userEvent.upload(input, file);
 
-    // Overview section should render (no Details required)
     await waitFor(() => {
       expect(
         screen.getByRole('heading', { name: /Overview Dashboard/i }),
       ).toBeInTheDocument();
     });
-
-    // SummaryAnalysis section should also render
     expect(
       await screen.findByRole('heading', { name: /Usage Patterns/i }),
     ).toBeInTheDocument();
 
-    // Clicking the Overview link should update the hash
     const overviewLink = screen.getByRole('link', { name: /Overview/i });
     expect(overviewLink).toHaveAttribute('href', '#overview');
     await userEvent.click(overviewLink);
     expect(window.location.hash).toBe('#overview');
-
-    // Ensure Papa.parse was invoked using worker mode
-    expect(parseMock).toHaveBeenCalledWith(
-      file,
-      expect.objectContaining({ worker: true }),
-    );
   });
 });

--- a/src/App.persistence.test.jsx
+++ b/src/App.persistence.test.jsx
@@ -7,7 +7,6 @@ import {
   within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import Papa from 'papaparse';
 import React from 'react';
 import App from './App.jsx';
 
@@ -50,25 +49,10 @@ describe('App persistence flow', () => {
     render(<App />);
 
     const summaryInput = screen.getByLabelText(/Summary CSV/i);
-    const parseMock = vi
-      .spyOn(Papa, 'parse')
-      .mockImplementation((file, options) => {
-        const rows = [
-          {
-            Date: '2025-06-01',
-            'Total Time': '08:00:00',
-            AHI: '5',
-            'Median EPAP': '6',
-          },
-        ];
-        options.chunk?.({ data: rows, meta: { cursor: file.size } });
-        options.complete?.({ data: rows });
-      });
     const summaryFile = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {
       type: 'text/csv',
     });
     fireEvent.change(summaryInput, { target: { files: [summaryFile] } });
-    parseMock.mockRestore();
     await screen.findAllByText('Median AHI');
 
     const remember = screen.getByLabelText(/remember data locally/i);
@@ -127,25 +111,6 @@ describe('App persistence flow', () => {
       detailsData: [],
     });
 
-    const parseMock = vi
-      .spyOn(Papa, 'parse')
-      .mockImplementation((file, options) => {
-        const rows = [
-          {
-            Date: '2025-06-01',
-            'Total Time': '08:00:00',
-            AHI: '5',
-            'Median EPAP': '6',
-          },
-        ];
-        if (options.chunk) {
-          options.chunk({ data: rows, meta: { cursor: file.size } });
-        }
-        if (options.complete) {
-          options.complete({ data: rows });
-        }
-      });
-
     render(<App />);
 
     const summaryInput = screen.getByLabelText(/Summary CSV/i);
@@ -168,8 +133,6 @@ describe('App persistence flow', () => {
       const updated = screen.getAllByText('Median AHI')[0].closest('.kpi-card');
       expect(within(updated).getByText('1.00')).toBeInTheDocument();
     });
-
-    parseMock.mockRestore();
   });
 
   it('retains saved session on reload before loading files', async () => {

--- a/src/App.worker.integration.test.jsx
+++ b/src/App.worker.integration.test.jsx
@@ -1,71 +1,45 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import Papa from 'papaparse';
 import App from './App';
 
 describe('Worker Integration Tests', () => {
+  const originalWorker = global.Worker;
+
   afterEach(() => {
-    vi.restoreAllMocks();
+    global.Worker = originalWorker;
   });
 
   it('parses summary CSV via worker and displays summary analysis', async () => {
-    // Spy on Papa.parse to simulate worker-based parsing
-    const parseMock = vi
-      .spyOn(Papa, 'parse')
-      .mockImplementation((file, options) => {
-        const rows = [
-          {
-            Date: '2025-06-01',
-            'Total Time': '08:00:00',
-            AHI: '5',
-            'Median EPAP': '6',
-          },
-        ];
-        // simulate a parsing chunk with progress update
-        if (options.chunk) {
-          options.chunk({ data: rows, meta: { cursor: file.size } });
-        }
-        // simulate completion of parsing
-        if (options.complete) {
-          options.complete({ data: rows });
-        }
-      });
-
     render(<App />);
-    // Upload a fake CSV file via the Summary CSV input
     const csvContent = 'Night,Data/Duration\n2025-06-01,8';
     const file = new File([csvContent], 'summary.csv', { type: 'text/csv' });
     const input = screen.getByLabelText(/Summary CSV/i);
     await userEvent.upload(input, file);
 
-    // Expect Papa.parse to be called with worker:true
-    expect(parseMock).toHaveBeenCalledWith(
-      file,
-      expect.objectContaining({ worker: true }),
-    );
-
-    // Wait for the summary analysis to render
     await waitFor(() => {
       expect(screen.getByText(/Total nights analyzed/i)).toBeInTheDocument();
     });
   });
 
   it('renders an error message when CSV parsing fails', async () => {
-    const parseMock = vi
-      .spyOn(Papa, 'parse')
-      .mockImplementation((file, options) => {
-        if (options.error) {
-          options.error(new Error('Malformed CSV'));
-        }
-      });
+    class ErrorWorker {
+      constructor() {}
+      postMessage() {
+        setTimeout(() => {
+          this.onmessage?.({
+            data: { type: 'error', error: 'Malformed CSV' },
+          });
+        }, 0);
+      }
+      terminate() {}
+    }
+    global.Worker = ErrorWorker;
 
     render(<App />);
     const file = new File(['bad'], 'bad.csv', { type: 'text/csv' });
     const input = screen.getByLabelText(/Summary CSV/i);
     await userEvent.upload(input, file);
-
-    expect(parseMock).toHaveBeenCalled();
 
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent('Malformed CSV');

--- a/src/components/RawDataExplorer.jsx
+++ b/src/components/RawDataExplorer.jsx
@@ -6,16 +6,23 @@ import { useData } from '../context/DataContext';
 function rowsToCsv(rows, columns) {
   if (!rows || rows.length === 0) return '';
   const cols = columns && columns.length ? columns : Object.keys(rows[0] || {});
-  const esc = (v) => {
+  const esc = (c, v) => {
     if (v === null || v === undefined) return '';
-    const s = String(v);
+    let s = v;
+    if (/date/i.test(c)) {
+      const d = dateFromAny(v);
+      s = d ? d.toISOString() : v;
+    }
+    s = String(s);
     if (s.includes(',') || s.includes('"') || s.includes('\n')) {
       return '"' + s.replace(/"/g, '""') + '"';
     }
     return s;
   };
   const header = cols.join(',');
-  const body = rows.map((r) => cols.map((c) => esc(r[c])).join(',')).join('\n');
+  const body = rows
+    .map((r) => cols.map((c) => esc(c, r[c])).join(','))
+    .join('\n');
   return header + '\n' + body;
 }
 
@@ -74,6 +81,14 @@ function dateFromAny(v) {
   if (v instanceof Date) return v;
   const d = new Date(v);
   return isNaN(d) ? null : d;
+}
+
+function formatCell(c, v) {
+  if (/date/i.test(c)) {
+    const d = dateFromAny(v);
+    return d ? d.toISOString() : '';
+  }
+  return String(v ?? '');
 }
 
 export default function RawDataExplorer({ onApplyDateFilter }) {
@@ -376,7 +391,7 @@ export default function RawDataExplorer({ onApplyDateFilter }) {
                               borderBottom: '1px solid #eee',
                             }}
                           >
-                            {String(row?.[c] ?? '')}
+                            {formatCell(c, row?.[c])}
                           </div>
                         ),
                       )}

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -24,3 +24,38 @@ if (typeof global.IntersectionObserver === 'undefined') {
   // eslint-disable-next-line no-undef
   global.IntersectionObserver = MockIO;
 }
+
+// Basic Web Worker stub for tests; individual tests can override as needed
+if (typeof global.Worker === 'undefined') {
+  class MockWorker {
+    constructor() {}
+    postMessage({ file } = {}) {
+      if (!file) return;
+      let rows;
+      if ((file.name || '').includes('summary')) {
+        rows = [
+          {
+            Date: '2025-06-01',
+            'Total Time': '08:00:00',
+            AHI: '5',
+            'Median EPAP': '6',
+          },
+        ];
+      } else {
+        rows = [
+          {
+            Event: 'ClearAirway',
+            DateTime: new Date('2025-06-01T00:00:00').getTime(),
+            'Data/Duration': 12,
+          },
+        ];
+      }
+      this.onmessage?.({ data: { type: 'progress', cursor: file.size } });
+      this.onmessage?.({ data: { type: 'rows', rows } });
+      this.onmessage?.({ data: { type: 'complete' } });
+    }
+    terminate() {}
+  }
+  // eslint-disable-next-line no-undef
+  global.Worker = MockWorker;
+}

--- a/src/workers/csv.worker.js
+++ b/src/workers/csv.worker.js
@@ -1,0 +1,42 @@
+import Papa from 'papaparse';
+import { FLG_BRIDGE_THRESHOLD } from '../utils/clustering.js';
+
+// Parses CSV files off the main thread and streams filtered rows
+self.onmessage = (e) => {
+  const { file, filterEvents } = e.data || {};
+  if (!file) return;
+  Papa.parse(file, {
+    worker: false,
+    header: true,
+    dynamicTyping: true,
+    skipEmptyLines: true,
+    chunkSize: 1024 * 1024,
+    chunk(results) {
+      self.postMessage({ type: 'progress', cursor: results.meta.cursor });
+      let rows = results.data;
+      if (filterEvents) {
+        rows = rows.filter((r) => {
+          const e = r['Event'];
+          if (e === 'FLG') return r['Data/Duration'] >= FLG_BRIDGE_THRESHOLD;
+          return ['ClearAirway', 'Obstructive', 'Mixed'].includes(e);
+        });
+      }
+      if (rows.length) {
+        const processed = rows.map((r) => {
+          if (r['DateTime']) {
+            const ms = new Date(r['DateTime']).getTime();
+            return { ...r, DateTime: ms };
+          }
+          return r;
+        });
+        self.postMessage({ type: 'rows', rows: processed });
+      }
+    },
+    complete() {
+      self.postMessage({ type: 'complete' });
+    },
+    error(err) {
+      self.postMessage({ type: 'error', error: err?.message || String(err) });
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- parse CSV files in dedicated worker and stream filtered batches to state
- format date columns for display and CSV export
- document worker-based filtering and incremental parsing

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c464f7c388832fab29301ff12bb783