### PR TITLE
feat: reuse ParamInput for apnea cluster settings

### DIFF
--- a/docs/user/05-faq.md
+++ b/docs/user/05-faq.md
@@ -60,7 +60,7 @@ Yes. Once the application is loaded, it functions without an internet connection
 
 ### How can I customize clustering thresholds?
 
-Open the “Clustered Apnea Events” panel and expand the settings section. You can adjust gap thresholds, FLG bridging, minimum density, and other parameters. Settings persist with the session.
+Open the “Clustered Apnea Events” panel and expand the settings section. Parameters include gap seconds, flow‑limitation bridge threshold and gap, edge enter and exit limits, minimum event count and total apnea seconds, maximum cluster duration, and minimum density. Settings persist with the session.
 
 ### Can I script analyses instead of using the UI?
 

--- a/src/components/ApneaClusterAnalysis.jsx
+++ b/src/components/ApneaClusterAnalysis.jsx
@@ -3,6 +3,51 @@ import { clustersToCsv } from '../utils/clustering';
 import ThemedPlot from './ThemedPlot';
 import GuideLink from './GuideLink';
 import VizHelp from './VizHelp';
+import ParamInput from './ParamInput';
+
+export const PARAM_FIELDS = [
+  { label: 'Gap sec', key: 'gapSec', inputProps: { type: 'number', min: 0 } },
+  {
+    label: 'FLG bridge ≥',
+    key: 'bridgeThreshold',
+    inputProps: { type: 'number', step: 0.05, min: 0, max: 2 },
+  },
+  {
+    label: 'FLG gap sec',
+    key: 'bridgeSec',
+    inputProps: { type: 'number', min: 0 },
+  },
+  {
+    label: 'Edge enter ≥',
+    key: 'edgeEnter',
+    inputProps: { type: 'number', step: 0.05, min: 0, max: 2 },
+  },
+  {
+    label: 'Edge exit ≥',
+    key: 'edgeExit',
+    inputProps: { type: 'number', step: 0.05, min: 0, max: 2 },
+  },
+  {
+    label: 'Min event count',
+    key: 'minCount',
+    inputProps: { type: 'number', min: 1 },
+  },
+  {
+    label: 'Min total apnea sec',
+    key: 'minTotalSec',
+    inputProps: { type: 'number', min: 0 },
+  },
+  {
+    label: 'Max cluster sec',
+    key: 'maxClusterSec',
+    inputProps: { type: 'number', min: 0 },
+  },
+  {
+    label: 'Min density (evt/min)',
+    key: 'minDensity',
+    inputProps: { type: 'number', step: 0.1, min: 0 },
+  },
+];
 
 function ApneaClusterAnalysis({ clusters, params, onParamChange, details }) {
   const [selected, setSelected] = useState(null);
@@ -67,130 +112,15 @@ function ApneaClusterAnalysis({ clusters, params, onParamChange, details }) {
         <span className="control-title" style={{ marginBottom: 6 }}>
           Clustering Params
         </span>
-        <div>
-          <label>
-            Gap sec
-            <input
-              type="number"
-              min={0}
-              value={params.gapSec}
-              onChange={(e) =>
-                onParamChange({ gapSec: Number(e.target.value) })
-              }
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            FLG bridge ≥
-            <input
-              type="number"
-              step="0.05"
-              min={0}
-              max={2}
-              value={params.bridgeThreshold}
-              onChange={(e) =>
-                onParamChange({ bridgeThreshold: Number(e.target.value) })
-              }
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            FLG gap sec
-            <input
-              type="number"
-              min={0}
-              value={params.bridgeSec}
-              onChange={(e) =>
-                onParamChange({ bridgeSec: Number(e.target.value) })
-              }
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            Edge enter ≥
-            <input
-              type="number"
-              step="0.05"
-              min={0}
-              max={2}
-              value={params.edgeEnter}
-              onChange={(e) =>
-                onParamChange({ edgeEnter: Number(e.target.value) })
-              }
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            Edge exit ≥
-            <input
-              type="number"
-              step="0.05"
-              min={0}
-              max={2}
-              value={params.edgeExit}
-              onChange={(e) =>
-                onParamChange({ edgeExit: Number(e.target.value) })
-              }
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            Min event count
-            <input
-              type="number"
-              min={1}
-              value={params.minCount}
-              onChange={(e) =>
-                onParamChange({ minCount: Number(e.target.value) })
-              }
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            Min total apnea sec
-            <input
-              type="number"
-              min={0}
-              value={params.minTotalSec}
-              onChange={(e) =>
-                onParamChange({ minTotalSec: Number(e.target.value) })
-              }
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            Max cluster sec
-            <input
-              type="number"
-              min={0}
-              value={params.maxClusterSec}
-              onChange={(e) =>
-                onParamChange({ maxClusterSec: Number(e.target.value) })
-              }
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            Min density (evt/min)
-            <input
-              type="number"
-              step="0.1"
-              min={0}
-              value={params.minDensity}
-              onChange={(e) =>
-                onParamChange({ minDensity: Number(e.target.value) })
-              }
-            />
-          </label>
-        </div>
+        {PARAM_FIELDS.map(({ label, key, inputProps }) => (
+          <ParamInput
+            key={key}
+            label={label}
+            value={params[key]}
+            onChange={(v) => onParamChange({ [key]: v })}
+            inputProps={inputProps}
+          />
+        ))}
         <div>
           <button onClick={handleExport}>Export CSV</button>
         </div>

--- a/src/components/ApneaClusterAnalysis.test.jsx
+++ b/src/components/ApneaClusterAnalysis.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as ACA from './ApneaClusterAnalysis.jsx';
 
@@ -62,5 +62,36 @@ describe('ApneaClusterAnalysis overlay', () => {
 describe('ApneaClusterAnalysis memoization', () => {
   it('exports a memoized component', () => {
     expect(ApneaClusterAnalysis.type).toBe(ACA.ApneaClusterAnalysis);
+  });
+});
+
+describe('ApneaClusterAnalysis params', () => {
+  it('renders parameter inputs and forwards changes', async () => {
+    const params = {
+      gapSec: 120,
+      bridgeThreshold: 0.1,
+      bridgeSec: 60,
+      edgeEnter: 0.5,
+      edgeExit: 0.35,
+      minCount: 1,
+      minTotalSec: 0,
+      maxClusterSec: 300,
+      minDensity: 0,
+    };
+    const onChange = vi.fn();
+    render(
+      <ApneaClusterAnalysis
+        clusters={[]}
+        params={params}
+        onParamChange={onChange}
+        details={[]}
+      />,
+    );
+    ACA.PARAM_FIELDS.forEach(({ label }) => {
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
+    });
+    const gap = screen.getByLabelText('Gap sec');
+    fireEvent.change(gap, { target: { value: '30' } });
+    expect(onChange).toHaveBeenLastCalledWith({ gapSec: 30 });
   });
 });

--- a/src/components/ParamInput.jsx
+++ b/src/components/ParamInput.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+function ParamInput({ label, value, onChange, inputProps = {} }) {
+  return (
+    <div>
+      <label>
+        {label}
+        <input
+          {...inputProps}
+          value={value}
+          onChange={(e) => onChange(Number(e.target.value))}
+        />
+      </label>
+    </div>
+  );
+}
+
+export default React.memo(ParamInput);

--- a/src/components/ParamInput.test.jsx
+++ b/src/components/ParamInput.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ParamInput from './ParamInput';
+
+describe('ParamInput', () => {
+  it('renders label and forwards numeric changes', async () => {
+    const onChange = vi.fn();
+    render(
+      <ParamInput
+        label="Gap sec"
+        value={10}
+        onChange={onChange}
+        inputProps={{ type: 'number', min: 0 }}
+      />,
+    );
+    const input = screen.getByLabelText('Gap sec');
+    fireEvent.change(input, { target: { value: '30' } });
+    expect(onChange).toHaveBeenLastCalledWith(30);
+  });
+});


### PR DESCRIPTION
## Summary
- extract reusable `ParamInput` for numeric fields
- map cluster parameter fields from a definitions array
- document available apnea cluster settings

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c680db63e0832f9242af392f2c1118