### PR TITLE
docs: clarify session clearing when disabling persistence

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -45,8 +45,9 @@ also logged to the console for debugging.
 - Session persistence flags
 
 The `useSessionManager` hook serializes this state to `IndexedDB` using the browser's `idb` wrapper when "Remember data
-locally" is enabled. Sessions can be saved, loaded, or cleared via controls in the header. Exporting a session produces
-JSON that can be imported on another machine; sensitive personal notes are intentionally excluded.
+locally" is enabled. Sessions can be saved, loaded, or cleared via controls in the header. Disabling persistence immediately
+removes the stored session to avoid stale data. Exporting a session produces JSON that can be imported on another machine;
+sensitive personal notes are intentionally excluded.
 
 ### Styling and Themes
 

--- a/src/hooks/useSessionManager.js
+++ b/src/hooks/useSessionManager.js
@@ -34,6 +34,7 @@ export function useSessionManager({
   }, [persistEnabled]);
 
   const prevPersistRef = useRef(persistEnabled);
+  // Clear stored session only when persistence is turned off to avoid stale data
   useEffect(() => {
     if (!persistEnabled && prevPersistRef.current) {
       clearLastSession().catch(() => {});

--- a/src/hooks/useSessionManager.test.js
+++ b/src/hooks/useSessionManager.test.js
@@ -143,4 +143,28 @@ describe('useSessionManager', () => {
     expect(clearLastSession).toHaveBeenCalledTimes(1);
     expect(memoryStore.last).toBeNull();
   });
+
+  it('does not clear session if persistence was never enabled', async () => {
+    memoryStore.last = buildSession({ summaryData: [{ AHI: '3' }] });
+    renderHook(() =>
+      useSessionManager({
+        summaryData: [],
+        detailsData: [],
+        clusterParams: {},
+        dateFilter: { start: null, end: null },
+        rangeA: { start: null, end: null },
+        rangeB: { start: null, end: null },
+        fnPreset: 'balanced',
+        setClusterParams: vi.fn(),
+        setDateFilter: vi.fn(),
+        setRangeA: vi.fn(),
+        setRangeB: vi.fn(),
+        setSummaryData: vi.fn(),
+        setDetailsData: vi.fn(),
+      }),
+    );
+    const { clearLastSession } = await import('../utils/db');
+    expect(clearLastSession).not.toHaveBeenCalled();
+    expect(memoryStore.last).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- explain that session cache is cleared when persistence is toggled off
- cover non-clearing case with `useSessionManager` tests
- note auto-clear behavior in architecture docs

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c686f1db5c832f90e5062d01e89666