### PR TITLE
docs: clarify worker chunk handling

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -9,9 +9,9 @@ framework abstractions. This section peels back the layers so you can orient you
 1. **Entry Point** – `main.jsx` bootstraps the React app and mounts `<App />` inside a root DOM node. Vite handles module
    loading and hot replacement during development.
 2. **File Upload** – The top portion of `App.jsx` exposes two file inputs for summary and details CSV exports. When a
-   file is chosen, a dedicated parser worker filters events, converts timestamps, and streams batches via `postMessage`
-   so the main thread receives only necessary data. Analysis sections render only after at least one row arrives,
-   preventing charts from initializing with empty data.
+   file is chosen, a dedicated parser worker filters events, converts timestamps, and streams batches with per-chunk
+   progress updates via `postMessage` so the main thread receives only necessary data and remains responsive. Analysis
+   sections render only after at least one row arrives, preventing charts from initializing with empty data.
 3. **Context Store** – Parsed rows and application settings live in `DataContext`. Components consume these values via
    hooks like `useData`, `useParameters`, and `useTheme`. Using context keeps props shallow and makes it easy to expose
    new pieces of state without threading them through every component.

--- a/src/workers/csv.worker.js
+++ b/src/workers/csv.worker.js
@@ -11,6 +11,7 @@ self.onmessage = (e) => {
     dynamicTyping: true,
     skipEmptyLines: true,
     chunkSize: 1024 * 1024,
+    // Runs in a worker: update progress and filter events per chunk to keep the UI responsive
     chunk(results) {
       self.postMessage({ type: 'progress', cursor: results.meta.cursor });
       let rows = results.data;

--- a/src/workers/csv.worker.test.js
+++ b/src/workers/csv.worker.test.js
@@ -1,0 +1,68 @@
+import Papa from 'papaparse';
+import { FLG_BRIDGE_THRESHOLD } from '../utils/clustering.js';
+import './csv.worker.js';
+
+describe('csv.worker chunk handler', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('updates progress and filters rows per chunk', () => {
+    const originalPost = self.postMessage;
+    self.postMessage = vi.fn();
+
+    vi.spyOn(Papa, 'parse').mockImplementation((file, opts) => {
+      opts.chunk({
+        data: [
+          {
+            Event: 'FLG',
+            'Data/Duration': FLG_BRIDGE_THRESHOLD - 0.01,
+            DateTime: '2025-01-01T00:00:00',
+          },
+          {
+            Event: 'FLG',
+            'Data/Duration': FLG_BRIDGE_THRESHOLD,
+            DateTime: '2025-01-01T00:01:00',
+          },
+          {
+            Event: 'ClearAirway',
+            'Data/Duration': 10,
+            DateTime: '2025-01-01T00:02:00',
+          },
+          {
+            Event: 'Noise',
+            'Data/Duration': 5,
+            DateTime: '2025-01-01T00:03:00',
+          },
+        ],
+        meta: { cursor: 321 },
+      });
+      opts.complete();
+    });
+
+    self.onmessage({ data: { file: 'file', filterEvents: true } });
+
+    expect(self.postMessage).toHaveBeenNthCalledWith(1, {
+      type: 'progress',
+      cursor: 321,
+    });
+    expect(self.postMessage).toHaveBeenNthCalledWith(2, {
+      type: 'rows',
+      rows: [
+        {
+          Event: 'FLG',
+          'Data/Duration': FLG_BRIDGE_THRESHOLD,
+          DateTime: new Date('2025-01-01T00:01:00').getTime(),
+        },
+        {
+          Event: 'ClearAirway',
+          'Data/Duration': 10,
+          DateTime: new Date('2025-01-01T00:02:00').getTime(),
+        },
+      ],
+    });
+    expect(self.postMessage).toHaveBeenNthCalledWith(3, { type: 'complete' });
+
+    self.postMessage = originalPost;
+  });
+});


### PR DESCRIPTION
## Summary
- document worker chunk handler filtering and progress updates
- add unit test for worker progress + filtering
- mention per-chunk progress in architecture docs

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c686f2591c832fa4b379a63a71ea94