### PR TITLE
feat: surface session import errors

### DIFF
--- a/src/hooks/useSessionManager.js
+++ b/src/hooks/useSessionManager.js
@@ -139,8 +139,13 @@ export function useSessionManager({
           setSummaryData(patch.summaryData || null);
           setDetailsData(patch.detailsData || null);
         }
-      } catch {
-        // ignore invalid JSON
+      } catch (err) {
+        const message =
+          'Could not import session. The file is not valid JSON or is missing required data. ' +
+          'Make sure you selected a session file exported from this app.\n\nDetails: ' +
+          (err instanceof Error ? err.message : String(err));
+        alert(message);
+        console.error('Session import failed:', err);
       }
     };
     reader.readAsText(file);


### PR DESCRIPTION
## Summary
- alert users when session import JSON is invalid, with error details
- test that malformed session imports show an alert without altering state
- simplify docs by removing redundant JSON import note

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7126824ac832fbd5f91fc435bb045