### PR TITLE
fix: ensure plot legends print in light theme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -574,4 +574,9 @@ select:focus-visible {
   select {
     display: none !important;
   }
+
+  /* Force Plotly legends to print with dark text for contrast */
+  .js-plotly-plot .legend text {
+    fill: #0b1220 !important;
+  }
 }

--- a/styles.print.test.js
+++ b/styles.print.test.js
@@ -18,4 +18,9 @@ describe('print styles', () => {
       /@media print[\s\S]*(\.guide-link|\.guide-inline)[\s\S]*display:\s*none/,
     );
   });
+  it('renders plotly legends with dark text', () => {
+    expect(css).toMatch(
+      /@media print[\s\S]*\.js-plotly-plot[\s\S]*\.legend[\s\S]*text[\s\S]*fill:\s*#0b1220/i,
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- force Plotly legends to use dark text in print view
- test that print CSS enforces light legend color

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c73291fee4832fbce7d6e4d8e88272