### PR TITLE
feat: add date range presets to global filter

### DIFF
--- a/src/App.header-date-filter.test.jsx
+++ b/src/App.header-date-filter.test.jsx
@@ -1,16 +1,45 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
 
 describe('Header date filter', () => {
-  it('renders date inputs inside the header', () => {
+  it('renders date inputs and presets inside the header', () => {
     render(<App />);
+    const presetSelect = screen.getByLabelText(/quick range/i);
     const startInput = screen.getByLabelText(/start date/i);
     const endInput = screen.getByLabelText(/end date/i);
     const header = startInput.closest('header');
     expect(header).toHaveClass('app-header');
     expect(endInput.closest('header')).toBe(header);
+    expect(presetSelect.closest('header')).toBe(header);
+  });
+
+  it('applies quick date range presets', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2023-01-10'));
+    render(<App />);
+    const presetSelect = screen.getByLabelText(/quick range/i);
+    const startInput = screen.getByLabelText(/start date/i);
+    const endInput = screen.getByLabelText(/end date/i);
+
+    fireEvent.change(presetSelect, { target: { value: '7' } });
+    expect(startInput).toHaveValue('2023-01-04');
+    expect(endInput).toHaveValue('2023-01-10');
+
+    fireEvent.change(presetSelect, { target: { value: '14' } });
+    expect(startInput).toHaveValue('2022-12-28');
+    expect(endInput).toHaveValue('2023-01-10');
+
+    fireEvent.change(presetSelect, { target: { value: '365' } });
+    expect(startInput).toHaveValue('2022-01-11');
+    expect(endInput).toHaveValue('2023-01-10');
+
+    fireEvent.change(presetSelect, { target: { value: 'all' } });
+    expect(startInput).toHaveValue('');
+    expect(endInput).toHaveValue('');
+    vi.useRealTimers();
   });
 
   it('ignores invalid dates without crashing', () => {

--- a/styles.css
+++ b/styles.css
@@ -150,6 +150,9 @@ h1 {
 .app-header .date-filter input {
   padding: 2px 4px;
 }
+.app-header .date-filter select {
+  padding: 2px 4px;
+}
 .app-header .date-filter button {
   padding: 2px 6px;
 }


### PR DESCRIPTION
## Summary
- expand quick date range presets (7, 14, 30, 90, 180 days, last year, last 5 years)
- generalize preset handler and document new options
- test additional presets in header date filter

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c72a034e20832fad6630a75f83c6dd