### PR TITLE
feat: add data import modal for CSV uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ If `BASE_URL` is unset, the build defaults to `/oscar-export-analyzer/`.
 ## Usage Walkthrough
 
 1. Export `Summary.csv` and optionally `Details.csv` from OSCAR.
-2. In the analyzer, use the **Summary CSV** picker to load the nightly summary file.
-3. Optionally load the **Details CSV** to unlock cluster detection and false‑negative analysis.
+2. On first load a full‑screen dialog appears; drag both files into it or use the picker to choose them.
+3. The app auto‑detects which is which and loads them in order, unlocking cluster detection and false‑negative analysis.
 4. Navigate via the sidebar to explore dashboards: **Overview**, **Usage Patterns**, **AHI Trends**, and more.
 5. Use the date range filter in the header to limit which nights are included across all views.
 6. Hover any chart element for a tooltip. Click legend items to toggle series visibility. Use the zoom controls to focus on ranges of interest.
-7. Enable **Remember data locally** if you want sessions to persist after closing the tab. Uploading a new Summary CSV replaces any previous session, and data is only saved after a file has been loaded so a refresh with no files won't wipe prior data. Use **Export JSON** to save a portable session snapshot.
+7. Enable **Remember data locally** if you want sessions to persist after closing the tab. Importing a new Summary CSV replaces any previous session, and data is only saved after a file has been loaded so a refresh with no files won't wipe prior data. Use **Export JSON** to save a portable session snapshot.
 
 ## Feature Tour
 

--- a/docs/user/01-getting-started.md
+++ b/docs/user/01-getting-started.md
@@ -32,11 +32,9 @@ The details export provides higher fidelity information:
 ## 2. Loading Files into the Analyzer
 
 1. Open <http://localhost:5173> after starting the development server or the deployed site if using a prebuilt bundle.
-2. Use the **Summary CSV** file input to choose the exported summary file.
-3. Optionally choose the **Details CSV** file. A background worker filters events and streams batches with progress updates so even huge files remain responsive.
+2. A full‑screen import dialog appears on first load. Drag both CSVs into it or click to choose them from disk.
+3. The app inspects the headers to classify files as summary or details and loads them in the proper order. A background worker filters events and streams batches with progress updates so even huge files remain responsive.
 4. Once loaded, the sidebar links become active and charts render automatically.
-
-![File pickers with summary and details loaded](../images/getting-started-upload.png)
 
 ### Handling Large Files
 
@@ -58,7 +56,7 @@ Use the theme toggle in the header to switch between light, dark, or system them
 
 ## 4. Saving and Restoring Sessions
 
-When **Remember data locally** is enabled, files and settings persist to `IndexedDB` so you can close and reopen the browser without reloading data. Uploading a new Summary CSV replaces the previous session. The app only saves after at least one CSV has been loaded, preventing a refresh on an empty page from wiping prior data. The **Save/Load/Clear** controls manage that last session; choosing **Load Saved** replaces whatever files or settings are currently in memory. Disabling **Remember data locally** clears it. Use **Export JSON** to download a portable snapshot that can be imported on another device. The exported JSON includes all loaded rows but excludes any personal notes you may have added.
+When **Remember data locally** is enabled, files and settings persist to `IndexedDB` so you can close and reopen the browser without reloading data. Importing a new Summary CSV replaces the previous session. The app only saves after at least one CSV has been loaded, preventing a refresh on an empty page from wiping prior data. The **Save/Load/Clear** controls manage that last session; choosing **Load Saved** replaces whatever files or settings are currently in memory. Disabling **Remember data locally** clears it. Use **Export JSON** to download a portable snapshot that can be imported on another device. The exported JSON includes all loaded rows but excludes any personal notes you may have added.
 
 ## 5. Example Workflow
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ import RawDataExplorer from './components/RawDataExplorer';
 import ErrorBoundary from './components/ErrorBoundary';
 import ThemeToggle from './components/ThemeToggle';
 import DocsModal from './components/DocsModal';
+import DataImportModal from './components/DataImportModal';
 import GuideLink from './components/GuideLink';
 import { buildSummaryAggregatesCSV, downloadTextFile } from './utils/export';
 import { DataProvider } from './context/DataContext';
@@ -78,6 +79,7 @@ function App() {
   const [rangeB, setRangeB] = useState({ start: null, end: null });
   const [guideOpen, setGuideOpen] = useState(false);
   const [guideAnchor, setGuideAnchor] = useState('');
+  const [importOpen, setImportOpen] = useState(true);
   const [clusterParams, setClusterParams] = useState({
     gapSec: APNEA_GAP_DEFAULT,
     bridgeThreshold: FLG_BRIDGE_THRESHOLD,
@@ -414,6 +416,22 @@ function App() {
       filteredSummary={filteredSummary}
       filteredDetails={filteredDetails}
     >
+      <DataImportModal
+        isOpen={importOpen && (!summaryData || !detailsData)}
+        onClose={() => setImportOpen(false)}
+        onSummaryFile={onSummaryFile}
+        onDetailsFile={onDetailsFile}
+        onLoadSaved={handleLoadSaved}
+        summaryData={summaryData}
+        detailsData={detailsData}
+        loadingSummary={loadingSummary}
+        loadingDetails={loadingDetails || processingDetails}
+        summaryProgress={summaryProgress}
+        summaryProgressMax={summaryProgressMax}
+        detailsProgress={detailsProgress}
+        detailsProgressMax={detailsProgressMax}
+        error={error}
+      />
       <header className="app-header">
         <div className="inner">
           <div className="title">
@@ -500,28 +518,6 @@ function App() {
           ))}
         </nav>
         <div className="section controls" aria-label="Data and export controls">
-          <label>
-            Summary CSV:{' '}
-            <input type="file" accept=".csv" onChange={onSummaryFile} />
-          </label>
-          {loadingSummary && (
-            <progress value={summaryProgress} max={summaryProgressMax} />
-          )}
-          <label>
-            Details CSV:{' '}
-            <input type="file" accept=".csv" onChange={onDetailsFile} />
-          </label>
-          {(loadingDetails || processingDetails) && (
-            <progress
-              value={loadingDetails ? detailsProgress : undefined}
-              max={loadingDetails ? detailsProgressMax : undefined}
-            />
-          )}
-          {error && (
-            <div role="alert" style={{ color: 'red' }}>
-              {error}
-            </div>
-          )}
           <div
             className="control-group"
             aria-label="Session controls"

--- a/src/App.navigation.test.jsx
+++ b/src/App.navigation.test.jsx
@@ -12,11 +12,16 @@ describe('In-page navigation', () => {
   it('renders Overview with only Summary CSV and updates hash on click', async () => {
     render(<App />);
 
-    const input = screen.getByLabelText(/Summary CSV/i);
-    const file = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {
+    const input = await screen.findByLabelText(/CSV files/i);
+    const summaryFile = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {
       type: 'text/csv',
     });
-    await userEvent.upload(input, file);
+    const detailsFile = new File(
+      ['Event,DateTime,Data/Duration\nClearAirway,2025-06-01T00:00:00,12'],
+      'details.csv',
+      { type: 'text/csv' },
+    );
+    await userEvent.upload(input, [summaryFile, detailsFile]);
 
     await waitFor(() => {
       expect(

--- a/src/App.print.test.jsx
+++ b/src/App.print.test.jsx
@@ -30,11 +30,16 @@ describe('Print Page control', () => {
 
     render(<App />);
 
-    const input = screen.getByLabelText(/Summary CSV/i);
-    const file = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {
+    const input = await screen.findByLabelText(/CSV files/i);
+    const summaryFile = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {
       type: 'text/csv',
     });
-    await userEvent.upload(input, file);
+    const detailsFile = new File(
+      ['Event,DateTime,Data/Duration\nClearAirway,2025-06-01T00:00:00,12'],
+      'details.csv',
+      { type: 'text/csv' },
+    );
+    await userEvent.upload(input, [summaryFile, detailsFile]);
 
     const printBtn = await screen.findByRole('button', { name: /Print Page/i });
     expect(printBtn).toBeEnabled();

--- a/src/App.toc-active.test.jsx
+++ b/src/App.toc-active.test.jsx
@@ -56,10 +56,16 @@ describe('TOC active highlighting', () => {
     mockSummaryParse();
     render(<App />);
 
-    const file = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {
+    const summaryFile = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {
       type: 'text/csv',
     });
-    await userEvent.upload(screen.getByLabelText(/Summary CSV/i), file);
+    const detailsFile = new File(
+      ['Event,DateTime,Data/Duration\nClearAirway,2025-06-01T00:00:00,12'],
+      'details.csv',
+      { type: 'text/csv' },
+    );
+    const input = await screen.findByLabelText(/CSV files/i);
+    await userEvent.upload(input, [summaryFile, detailsFile]);
 
     await waitFor(() => {
       expect(

--- a/src/App.worker.integration.test.jsx
+++ b/src/App.worker.integration.test.jsx
@@ -10,12 +10,20 @@ describe('Worker Integration Tests', () => {
     global.Worker = originalWorker;
   });
 
-  it('parses summary CSV via worker and displays summary analysis', async () => {
+  it('parses CSVs via worker and displays summary analysis', async () => {
     render(<App />);
-    const csvContent = 'Night,Data/Duration\n2025-06-01,8';
-    const file = new File([csvContent], 'summary.csv', { type: 'text/csv' });
-    const input = screen.getByLabelText(/Summary CSV/i);
-    await userEvent.upload(input, file);
+    const summary = new File(
+      ['Night,Data/Duration\n2025-06-01,8'],
+      'summary.csv',
+      { type: 'text/csv' },
+    );
+    const details = new File(
+      ['Event,DateTime,Data/Duration\nClearAirway,2025-06-01T00:00:00,12'],
+      'details.csv',
+      { type: 'text/csv' },
+    );
+    const input = screen.getByLabelText(/CSV files/i);
+    await userEvent.upload(input, [summary, details]);
 
     await waitFor(() => {
       expect(screen.getByText(/Total nights analyzed/i)).toBeInTheDocument();
@@ -38,7 +46,7 @@ describe('Worker Integration Tests', () => {
 
     render(<App />);
     const file = new File(['bad'], 'bad.csv', { type: 'text/csv' });
-    const input = screen.getByLabelText(/Summary CSV/i);
+    const input = screen.getByLabelText(/CSV files/i);
     await userEvent.upload(input, file);
 
     await waitFor(() => {

--- a/src/components/DataImportModal.jsx
+++ b/src/components/DataImportModal.jsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { getLastSession } from '../utils/db';
+
+export default function DataImportModal({
+  isOpen,
+  onClose,
+  onSummaryFile,
+  onDetailsFile,
+  onLoadSaved,
+  summaryData,
+  detailsData,
+  loadingSummary,
+  loadingDetails,
+  summaryProgress,
+  summaryProgressMax,
+  detailsProgress,
+  detailsProgressMax,
+  error,
+}) {
+  const [hasSaved, setHasSaved] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    getLastSession()
+      .then((sess) => setHasSaved(!!sess))
+      .catch(() => setHasSaved(false));
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (
+      summaryData &&
+      detailsData &&
+      !loadingSummary &&
+      !loadingDetails &&
+      isOpen
+    ) {
+      onClose();
+    }
+  }, [
+    summaryData,
+    detailsData,
+    loadingSummary,
+    loadingDetails,
+    isOpen,
+    onClose,
+  ]);
+
+  const classifyFile = async (file) => {
+    const text = await new Response(file).text();
+    const header = text.split(/\r?\n/)[0];
+    return /event/i.test(header) ? 'details' : 'summary';
+  };
+
+  const handleFiles = useCallback(
+    async (fileList) => {
+      const files = Array.from(fileList || []);
+      if (!files.length) return;
+      const classified = await Promise.all(
+        files.map(async (f) => ({ type: await classifyFile(f), file: f })),
+      );
+      const summary = classified.find((c) => c.type === 'summary')?.file;
+      const details = classified.find((c) => c.type === 'details')?.file;
+      if (summary) {
+        onSummaryFile({ target: { files: [summary] } });
+      }
+      if (details) {
+        onDetailsFile({ target: { files: [details] } });
+      }
+    },
+    [onSummaryFile, onDetailsFile],
+  );
+
+  const onInputChange = (e) => handleFiles(e.target.files);
+  const onDrop = (e) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+  const onDragOver = (e) => e.preventDefault();
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Import Data"
+    >
+      <div
+        className="modal"
+        style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+      >
+        <h3 style={{ margin: 0 }}>Load OSCAR CSVs</h3>
+        {hasSaved && (
+          <button className="btn-primary" onClick={onLoadSaved}>
+            Load previous session
+          </button>
+        )}
+        <div
+          onDrop={onDrop}
+          onDragOver={onDragOver}
+          style={{
+            flex: 1,
+            border: '2px dashed var(--color-border)',
+            padding: 20,
+            borderRadius: 8,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            textAlign: 'center',
+            gap: 12,
+          }}
+        >
+          <p style={{ margin: 0 }}>
+            Drag and drop Summary and Details CSVs here or choose files
+          </p>
+          <input
+            type="file"
+            accept=".csv"
+            multiple
+            onChange={onInputChange}
+            aria-label="CSV files"
+          />
+          {loadingSummary && (
+            <progress
+              value={summaryProgress}
+              max={summaryProgressMax}
+              style={{ width: '100%' }}
+            />
+          )}
+          {loadingDetails && (
+            <progress
+              value={detailsProgress}
+              max={detailsProgressMax}
+              style={{ width: '100%' }}
+            />
+          )}
+          {error && (
+            <div role="alert" style={{ color: 'red' }}>
+              {error}
+            </div>
+          )}
+        </div>
+        <button className="btn-ghost" onClick={onClose} aria-label="Close">
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add full-screen DataImportModal to load summary/details CSVs with drag-and-drop and saved-session detection
- replace inline file pickers with startup modal and update docs and tests accordingly

## Testing
- `npm run format`
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c73ca78e80832fa2d8a5d5f983a4ed