### PR TITLE
feat: show CSV import progress in header

### DIFF
--- a/docs/user/01-getting-started.md
+++ b/docs/user/01-getting-started.md
@@ -33,7 +33,7 @@ The details export provides higher fidelity information:
 
 1. Open <http://localhost:5173> after starting the development server or the deployed site if using a prebuilt bundle.
 2. A full‑screen import dialog appears on first load. Drag both CSVs into it or click to choose them from disk.
-3. The app inspects the headers to classify files as summary or details and loads them in the proper order. A background worker filters events and streams batches with progress updates so even huge files remain responsive.
+3. The app inspects the headers to classify files as summary or details and loads them in the proper order. A background worker filters events and streams batches with progress updates so even huge files remain responsive. A small status line in the page header shows the current step along with a compact progress bar.
 4. Once loaded, the sidebar links become active and charts render automatically.
 
 ### Handling Large Files

--- a/src/App.import-progress.test.jsx
+++ b/src/App.import-progress.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from './App';
+
+describe('Header import progress', () => {
+  const OriginalWorker = global.Worker;
+
+  beforeEach(() => {
+    class MockWorker {
+      postMessage() {
+        setTimeout(() => {
+          this.onmessage?.({ data: { type: 'progress', cursor: 50 } });
+        }, 0);
+        setTimeout(() => {
+          this.onmessage?.({ data: { type: 'rows', rows: [], cursor: 50 } });
+          this.onmessage?.({ data: { type: 'complete' } });
+        }, 500);
+      }
+      terminate() {}
+    }
+    global.Worker = MockWorker;
+  });
+
+  afterEach(() => {
+    global.Worker = OriginalWorker;
+  });
+
+  it('shows progress text and bar in the header during import', async () => {
+    render(<App />);
+    const input = screen.getByLabelText(/CSV files/i);
+    const file = new File(['Date\n2025-06-01'], 'summary.csv', {
+      type: 'text/csv',
+    });
+    await userEvent.upload(input, file);
+
+    const header = screen.getByRole('banner');
+    expect(
+      await within(header).findByText(/Importing summary CSV/i),
+    ).toBeInTheDocument();
+    expect(within(header).getByRole('progressbar')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        within(header).queryByText(/Importing summary CSV/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -503,6 +503,48 @@ function App() {
             </button>
           </div>
         </div>
+        {(loadingSummary || loadingDetails || processingDetails) && (
+          <div className="import-progress" aria-live="polite">
+            <span>
+              {loadingSummary &&
+                `Importing summary CSV${
+                  summaryProgressMax
+                    ? ` (${Math.round(
+                        (summaryProgress / summaryProgressMax) * 100,
+                      )}%)`
+                    : ''
+                }`}
+              {loadingDetails && !loadingSummary &&
+                `Importing details CSV${
+                  detailsProgressMax
+                    ? ` (${Math.round(
+                        (detailsProgress / detailsProgressMax) * 100,
+                      )}%)`
+                    : ''
+                }`}
+              {processingDetails &&
+                !loadingSummary &&
+                !loadingDetails &&
+                'Processing events...'}
+            </span>
+            <progress
+              value={
+                loadingSummary
+                  ? summaryProgress
+                  : loadingDetails
+                  ? detailsProgress
+                  : undefined
+              }
+              max={
+                loadingSummary
+                  ? summaryProgressMax
+                  : loadingDetails
+                  ? detailsProgressMax
+                  : undefined
+              }
+            />
+          </div>
+        )}
       </header>
       <div className="container">
         <nav className="toc">

--- a/styles.css
+++ b/styles.css
@@ -163,6 +163,20 @@ h1 {
   gap: 8px;
 }
 
+.app-header .import-progress {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 0 16px 6px;
+  font-size: 0.75rem;
+}
+
+.app-header .import-progress progress {
+  width: 120px;
+  height: 4px;
+}
+
 /* Theme toggle */
 .theme-toggle {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- show import progress in the page header with contextual text and a tiny progress bar
- document header progress indicator in getting-started guide
- cover header progress with a new integration test
- remove README mention per review

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c74db46880832f9831a9307bb71aa2