### PR TITLE
feat: add header menu and remove body export controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If `BASE_URL` is unset, the build defaults to `/oscar-export-analyzer/`.
 4. Navigate via the sidebar to explore dashboards: **Overview**, **Usage Patterns**, **AHI Trends**, and more.
 5. Use the date range filter in the header to limit which nights are included across all views.
 6. Hover any chart element for a tooltip. Click legend items to toggle series visibility. Use the zoom controls to focus on ranges of interest.
-7. Sessions persist automatically to your browser's storage. Drop a saved session JSON on the splash screen or click **Load previous session** there to restore it. Use **Export JSON** to save a portable snapshot.
+7. Sessions persist automatically to your browser's storage. Drop a saved session JSON on the splash screen or click **Load previous session** there to restore it. Use the header menu's **Export JSON** to save a portable snapshot.
 
 ## Feature Tour
 

--- a/docs/user/02-visualizations.md
+++ b/docs/user/02-visualizations.md
@@ -107,9 +107,9 @@ A virtualized table renders the raw Summary and Details CSV contents. Features i
 ## Persistence, Export, and Reporting
 
 - **Session Persistence** – Stores uploaded files and settings in `IndexedDB` when enabled.
-- **JSON Export/Import** – Saves or restores a session snapshot.
-- **Aggregates CSV** – Exports computed nightly metrics for external analysis.
-- **Print Page** – The app's print control triggers your browser's print dialog. The print view omits navigation and buttons while keeping charts and summary tables for saving or sharing.
+- **JSON Export/Import** – Use the header menu's **Export JSON** to save or restore a session snapshot.
+- **Aggregates CSV** – Export computed nightly metrics via the menu for external analysis.
+- **Print Page** – Choose **Print Page** from the menu to trigger your browser's print dialog. The print view omits navigation and buttons while keeping charts and summary tables for saving or sharing.
 
 ## Interpretation Tips
 

--- a/docs/user/05-faq.md
+++ b/docs/user/05-faq.md
@@ -18,7 +18,7 @@ Sessions are saved automatically to IndexedDB. Uploading a new Summary CSV overw
 
 ### Can I export results for my doctor?
 
-Use the **Print Page** control to generate a PDF or the aggregates CSV for sharing. The print view hides navigation and buttons but preserves charts and summary tables.
+Use the menu's **Print Page** option or aggregates CSV export for sharing. The print view hides navigation and buttons but preserves charts and summary tables.
 
 ### Is my data uploaded anywhere?
 

--- a/docs/user/06-troubleshooting.md
+++ b/docs/user/06-troubleshooting.md
@@ -45,7 +45,7 @@ This chapter lists common issues and step‑by‑step solutions. Always ensure y
 ### Saved sessions disappear after closing the browser
 
 - Some privacy settings clear `IndexedDB` on exit. Check your browser’s cookie and site‑data retention policies.
-- In private/incognito mode, enable **Export JSON** to manually save a session between visits.
+- In private/incognito mode, use the menu's **Export JSON** to manually save a session between visits.
 
 ### Unable to import a previously exported JSON
 

--- a/src/App.print.test.jsx
+++ b/src/App.print.test.jsx
@@ -41,9 +41,13 @@ describe('Print Page control', () => {
     );
     await userEvent.upload(input, [summaryFile, detailsFile]);
 
-    const printBtn = await screen.findByRole('button', { name: /Print Page/i });
-    expect(printBtn).toBeEnabled();
-    await userEvent.click(printBtn);
+    const menuBtn = await screen.findByRole('button', { name: /menu/i });
+    await userEvent.click(menuBtn);
+    const printItem = await screen.findByRole('menuitem', {
+      name: /Print Page/i,
+    });
+    expect(printItem).toBeEnabled();
+    await userEvent.click(printItem);
     expect(window.print).toHaveBeenCalled();
 
     expect(

--- a/src/components/HeaderMenu.jsx
+++ b/src/components/HeaderMenu.jsx
@@ -1,0 +1,110 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+export default function HeaderMenu({
+  onOpenImport,
+  onExportJson,
+  onExportCsv,
+  onClearSession,
+  onPrint,
+  onOpenGuide,
+  hasAnyData,
+  summaryAvailable,
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const handleClick = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    if (open) document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const close = () => setOpen(false);
+
+  return (
+    <div className="app-menu" ref={ref}>
+      <button
+        className="btn-ghost"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        Menu
+      </button>
+      {open && (
+        <div className="menu-list" role="menu">
+          <button
+            role="menuitem"
+            onClick={() => {
+              onOpenImport();
+              close();
+            }}
+          >
+            Load Data
+          </button>
+          <button
+            role="menuitem"
+            onClick={() => {
+              onExportJson();
+              close();
+            }}
+            disabled={!hasAnyData}
+          >
+            Export JSON
+          </button>
+          <button
+            role="menuitem"
+            onClick={() => {
+              onExportCsv();
+              close();
+            }}
+            disabled={!summaryAvailable}
+          >
+            Export Aggregates CSV
+          </button>
+          <button
+            role="menuitem"
+            onClick={() => {
+              onClearSession();
+              close();
+            }}
+          >
+            Delete saved session
+          </button>
+          <button
+            role="menuitem"
+            onClick={() => {
+              onPrint();
+              close();
+            }}
+            disabled={!summaryAvailable}
+          >
+            Print Page
+          </button>
+          <button
+            role="menuitem"
+            onClick={() => {
+              onOpenGuide();
+              close();
+            }}
+          >
+            Guide
+          </button>
+          <a
+            role="menuitem"
+            href="https://github.com/kabaka/oscar-export-analyzer"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={close}
+          >
+            GitHub Project
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/HeaderMenu.test.jsx
+++ b/src/components/HeaderMenu.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import HeaderMenu from './HeaderMenu';
+
+describe('HeaderMenu', () => {
+  it('toggles and triggers actions', async () => {
+    const onPrint = vi.fn();
+    render(
+      <HeaderMenu
+        onOpenImport={() => {}}
+        onExportJson={() => {}}
+        onExportCsv={() => {}}
+        onClearSession={() => {}}
+        onPrint={onPrint}
+        onOpenGuide={() => {}}
+        hasAnyData={true}
+        summaryAvailable={true}
+      />,
+    );
+    const menuBtn = screen.getByRole('button', { name: /menu/i });
+    await userEvent.click(menuBtn);
+    const printItem = screen.getByRole('menuitem', { name: /print page/i });
+    await userEvent.click(printItem);
+    expect(onPrint).toHaveBeenCalled();
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -163,6 +163,38 @@ h1 {
   gap: 8px;
 }
 
+.app-menu {
+  position: relative;
+}
+
+.app-menu .menu-list {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-2);
+  margin-top: 4px;
+  padding: 4px;
+  z-index: 10;
+}
+
+.app-menu .menu-list [role='menuitem'] {
+  padding: 4px 8px;
+  background: none;
+  border: none;
+  text-align: left;
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-menu .menu-list [role='menuitem']:hover {
+  background: color-mix(in oklab, var(--color-kpi-bg) 60%, transparent);
+}
+
 .app-header .import-progress {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- replace header Guide button with a menu housing data management, export, print and guide links
- drop export/print controls from body section
- document and test new menu workflow

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c75b4d174c832fa1e2cc3164ae2b16