### PR TITLE
feat: improve data import modal styling

### DIFF
--- a/src/components/DataImportModal.jsx
+++ b/src/components/DataImportModal.jsx
@@ -106,11 +106,22 @@ export default function DataImportModal({
     >
       <div
         className="modal"
-        style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+        style={{
+          padding: 24,
+          width: 'min(480px, 96vw)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 24,
+          alignItems: 'center',
+        }}
       >
-        <h3 style={{ margin: 0 }}>Load OSCAR CSVs</h3>
+        <h3 style={{ margin: 0, textAlign: 'center' }}>Load OSCAR CSVs</h3>
         {hasSaved && (
-          <button className="btn-primary" onClick={onLoadSaved}>
+          <button
+            className="btn-primary"
+            onClick={onLoadSaved}
+            style={{ alignSelf: 'center' }}
+          >
             Load previous session
           </button>
         )}
@@ -118,6 +129,7 @@ export default function DataImportModal({
           onDrop={onDrop}
           onDragOver={onDragOver}
           style={{
+            width: '100%',
             flex: 1,
             border: '2px dashed var(--color-border)',
             padding: 20,
@@ -161,7 +173,12 @@ export default function DataImportModal({
             </div>
           )}
         </div>
-        <button className="btn-ghost" onClick={onClose} aria-label="Close">
+        <button
+          className="btn-ghost"
+          onClick={onClose}
+          aria-label="Close"
+          style={{ alignSelf: 'center' }}
+        >
           Close
         </button>
       </div>

--- a/src/components/DataImportModal.test.jsx
+++ b/src/components/DataImportModal.test.jsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import DataImportModal from './DataImportModal.jsx';
+
+vi.mock('../utils/db', () => ({
+  getLastSession: vi.fn(async () => ({})),
+}));
+
+const noop = () => {};
+
+describe('DataImportModal layout', () => {
+  it('adds padding and centers actions', async () => {
+    render(
+      <DataImportModal
+        isOpen
+        onClose={noop}
+        onSummaryFile={noop}
+        onDetailsFile={noop}
+        onLoadSaved={noop}
+        onSessionFile={noop}
+        summaryData={null}
+        detailsData={null}
+        loadingSummary={false}
+        loadingDetails={false}
+        summaryProgress={0}
+        summaryProgressMax={0}
+        detailsProgress={0}
+        detailsProgressMax={0}
+      />,
+    );
+
+    const modal = document.querySelector('.modal');
+    expect(modal).toHaveStyle({ padding: '24px' });
+
+    const loadBtn = await screen.findByRole('button', {
+      name: /load previous session/i,
+    });
+    expect(loadBtn).toHaveStyle({ alignSelf: 'center' });
+
+    const closeBtn = screen.getByRole('button', { name: /close/i });
+    expect(closeBtn).toHaveStyle({ alignSelf: 'center' });
+  });
+});


### PR DESCRIPTION
## Summary
- add padding and centered layout to data import modal
- avoid full-width action buttons and constrain modal width
- test modal padding and button alignment

## Testing
- `npm run lint`
- `npm test -- --run` *(fails: require() of ES module vite)*
- `npm run build` *(fails: require() of ES module vite)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a5d3b6e0832fa52705462acbb170