### PR TITLE
fix: prevent header menu text wrapping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -180,6 +180,7 @@ h1 {
   margin-top: 4px;
   padding: 4px;
   z-index: 10;
+  width: max-content;
 }
 
 .app-menu .menu-list [role='menuitem'] {
@@ -189,6 +190,7 @@ h1 {
   text-align: left;
   color: inherit;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .app-menu .menu-list [role='menuitem']:hover {

--- a/styles.menu.test.js
+++ b/styles.menu.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('menu styles', () => {
+  const css = fs.readFileSync(path.join(process.cwd(), 'styles.css'), 'utf8');
+
+  it('sets menu width to fit items', () => {
+    expect(css).toMatch(
+      /\.app-menu\s+\.menu-list\s*{[\s\S]*width:\s*max-content/,
+    );
+  });
+
+  it('prevents menu items from wrapping', () => {
+    expect(css).toMatch(
+      /\.app-menu\s+\.menu-list\s+\[role='menuitem'\]\s*{[\s\S]*white-space:\s*nowrap/,
+    );
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/setupTests.js',
-    include: ['src/**/*.test.{js,jsx,ts,tsx}'],
+    include: ['src/**/*.test.{js,jsx,ts,tsx}', 'styles.*.test.js'],
   },
   // Treat any Vite/Rollup warnings as errors to enforce clean builds
   build: {


### PR DESCRIPTION
## Summary
- widen header menu so items never wrap
- cover menu width with CSS test
- include style tests in Vitest config

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7ab34be1c832f9b5ad14de2b1fffb