### PR TITLE
fix: enable reimport and organize menu

### DIFF
--- a/docs/user/05-faq.md
+++ b/docs/user/05-faq.md
@@ -16,6 +16,10 @@ Ensure the file is exported from OSCAR and uses UTF‑8 encoding. Files edited i
 
 Sessions are saved automatically to IndexedDB. Uploading a new Summary CSV overwrites any prior session and resets Details until a matching file is provided. The app only writes to storage after data has been loaded, so refreshing before uploading files won't wipe the stored session. Use the splash screen's **Load previous session** button or drop a session JSON file to restore that session.
 
+### How do I load new files after already importing data?
+
+Open the header menu and choose **Load Data** to reopen the import dialog. You can replace the current session by selecting new Summary and Details CSVs or a saved session JSON.
+
 ### Can I export results for my doctor?
 
 Use the menu's **Print Page** option or aggregates CSV export for sharing. The print view hides navigation and buttons but preserves charts and summary tables.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -435,7 +435,7 @@ function App() {
       filteredDetails={filteredDetails}
     >
       <DataImportModal
-        isOpen={importOpen && (!summaryData || !detailsData)}
+        isOpen={importOpen}
         onClose={() => setImportOpen(false)}
         onSummaryFile={onSummaryFile}
         onDetailsFile={onDetailsFile}

--- a/src/components/DataImportModal.jsx
+++ b/src/components/DataImportModal.jsx
@@ -20,6 +20,7 @@ export default function DataImportModal({
 }) {
   const [hasSaved, setHasSaved] = useState(false);
   const [localError, setLocalError] = useState('');
+  const [shouldAutoClose, setShouldAutoClose] = useState(false);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -29,21 +30,30 @@ export default function DataImportModal({
   }, [isOpen]);
 
   useEffect(() => {
+    if (loadingSummary || loadingDetails) {
+      setShouldAutoClose(true);
+    }
+  }, [loadingSummary, loadingDetails]);
+
+  useEffect(() => {
     if (
+      isOpen &&
+      shouldAutoClose &&
       summaryData &&
       detailsData &&
       !loadingSummary &&
-      !loadingDetails &&
-      isOpen
+      !loadingDetails
     ) {
+      setShouldAutoClose(false);
       onClose();
     }
   }, [
+    isOpen,
+    shouldAutoClose,
     summaryData,
     detailsData,
     loadingSummary,
     loadingDetails,
-    isOpen,
     onClose,
   ]);
 

--- a/src/components/DataImportModal.test.jsx
+++ b/src/components/DataImportModal.test.jsx
@@ -41,4 +41,30 @@ describe('DataImportModal layout', () => {
     const closeBtn = screen.getByRole('button', { name: /close/i });
     expect(closeBtn).toHaveStyle({ alignSelf: 'center' });
   });
+
+  it('remains open when reopened with loaded data', () => {
+    const onClose = vi.fn();
+    render(
+      <DataImportModal
+        isOpen
+        onClose={onClose}
+        onSummaryFile={noop}
+        onDetailsFile={noop}
+        onLoadSaved={noop}
+        onSessionFile={noop}
+        summaryData={[{}]}
+        detailsData={[{}]}
+        loadingSummary={false}
+        loadingDetails={false}
+        summaryProgress={0}
+        summaryProgressMax={0}
+        detailsProgress={0}
+        detailsProgressMax={0}
+      />,
+    );
+    expect(
+      screen.getByRole('dialog', { name: /import data/i }),
+    ).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/HeaderMenu.jsx
+++ b/src/components/HeaderMenu.jsx
@@ -37,72 +37,78 @@ export default function HeaderMenu({
       </button>
       {open && (
         <div className="menu-list" role="menu">
-          <button
-            role="menuitem"
-            onClick={() => {
-              onOpenImport();
-              close();
-            }}
-          >
-            Load Data
-          </button>
-          <button
-            role="menuitem"
-            onClick={() => {
-              onExportJson();
-              close();
-            }}
-            disabled={!hasAnyData}
-          >
-            Export JSON
-          </button>
-          <button
-            role="menuitem"
-            onClick={() => {
-              onExportCsv();
-              close();
-            }}
-            disabled={!summaryAvailable}
-          >
-            Export Aggregates CSV
-          </button>
-          <button
-            role="menuitem"
-            onClick={() => {
-              onClearSession();
-              close();
-            }}
-          >
-            Delete saved session
-          </button>
-          <button
-            role="menuitem"
-            onClick={() => {
-              onPrint();
-              close();
-            }}
-            disabled={!summaryAvailable}
-          >
-            Print Page
-          </button>
-          <button
-            role="menuitem"
-            onClick={() => {
-              onOpenGuide();
-              close();
-            }}
-          >
-            Guide
-          </button>
-          <a
-            role="menuitem"
-            href="https://github.com/kabaka/oscar-export-analyzer"
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={close}
-          >
-            GitHub Project
-          </a>
+          <div className="menu-section" role="group">
+            <button
+              role="menuitem"
+              onClick={() => {
+                onOpenImport();
+                close();
+              }}
+            >
+              Load Data
+            </button>
+            <button
+              role="menuitem"
+              onClick={() => {
+                onExportJson();
+                close();
+              }}
+              disabled={!hasAnyData}
+            >
+              Export JSON
+            </button>
+            <button
+              role="menuitem"
+              onClick={() => {
+                onExportCsv();
+                close();
+              }}
+              disabled={!summaryAvailable}
+            >
+              Export Aggregates CSV
+            </button>
+            <button
+              role="menuitem"
+              onClick={() => {
+                onPrint();
+                close();
+              }}
+              disabled={!summaryAvailable}
+            >
+              Print Page
+            </button>
+          </div>
+          <div className="menu-section" role="group">
+            <button
+              role="menuitem"
+              onClick={() => {
+                onClearSession();
+                close();
+              }}
+            >
+              Delete saved session
+            </button>
+          </div>
+          <div className="menu-section" role="group">
+            <button
+              role="menuitem"
+              onClick={() => {
+                onOpenGuide();
+                close();
+              }}
+            >
+              Guide
+            </button>
+            <a
+              role="menuitem"
+              href="https://github.com/kabaka/oscar-export-analyzer"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={close}
+            >
+              GitHub Project
+            </a>
+          </div>
         </div>
       )}
     </div>

--- a/src/components/HeaderMenu.test.jsx
+++ b/src/components/HeaderMenu.test.jsx
@@ -5,11 +5,12 @@ import { vi } from 'vitest';
 import HeaderMenu from './HeaderMenu';
 
 describe('HeaderMenu', () => {
-  it('toggles and triggers actions', async () => {
+  it('triggers menu actions', async () => {
+    const onOpenImport = vi.fn();
     const onPrint = vi.fn();
     render(
       <HeaderMenu
-        onOpenImport={() => {}}
+        onOpenImport={onOpenImport}
         onExportJson={() => {}}
         onExportCsv={() => {}}
         onClearSession={() => {}}
@@ -20,6 +21,10 @@ describe('HeaderMenu', () => {
       />,
     );
     const menuBtn = screen.getByRole('button', { name: /menu/i });
+    await userEvent.click(menuBtn);
+    const loadItem = screen.getByRole('menuitem', { name: /load data/i });
+    await userEvent.click(loadItem);
+    expect(onOpenImport).toHaveBeenCalled();
     await userEvent.click(menuBtn);
     const printItem = screen.getByRole('menuitem', { name: /print page/i });
     await userEvent.click(printItem);

--- a/styles.css
+++ b/styles.css
@@ -183,6 +183,12 @@ h1 {
   width: max-content;
 }
 
+.app-menu .menu-list .menu-section + .menu-section {
+  border-top: 1px solid var(--color-border);
+  margin-top: 4px;
+  padding-top: 4px;
+}
+
 .app-menu .menu-list [role='menuitem'] {
   padding: 4px 8px;
   background: none;


### PR DESCRIPTION
## Summary
- allow reopening the import dialog even after data is loaded
- group header menu items into clearly separated sections
- document how to reload files and add regression tests

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7af826aac832f9bc3b1c06c229420