### PR TITLE
fix: orient mann-whitney effect sizes

### DIFF
--- a/src/components/EpapTrendsCharts.jsx
+++ b/src/components/EpapTrendsCharts.jsx
@@ -642,7 +642,7 @@ function EpapTrendsCharts({ data }) {
           MW U = {isFinite(titration.U) ? titration.U.toFixed(1) : '—'}, p
           {titration.method === 'exact' ? ' (exact)' : ' (normal)'} ≈{' '}
           {isFinite(titration.p) ? titration.p.toExponential(2) : '—'}, effect
-          (rank-biserial) ≈{' '}
+          (rank-biserial, high &gt; low) ≈{' '}
           {isFinite(titration.effect) ? titration.effect.toFixed(2) : '—'}
           {isFinite(titration.effect_ci_low) &&
           isFinite(titration.effect_ci_high)

--- a/src/components/RangeComparisons.jsx
+++ b/src/components/RangeComparisons.jsx
@@ -64,7 +64,7 @@ export default function RangeComparisons({ rangeA, rangeB }) {
             <th>B (mean)</th>
             <th>Delta (B−A)</th>
             <th>MW p</th>
-            <th>Effect</th>
+            <th>Effect (B &gt; A)</th>
           </tr>
         </thead>
         <tbody>
@@ -76,7 +76,7 @@ export default function RangeComparisons({ rangeA, rangeB }) {
             <td>
               {isFinite(kpi.usageMW.p) ? kpi.usageMW.p.toExponential(2) : '—'}
             </td>
-            <td>
+            <td title="Rank-biserial effect; positive means B tends to be larger">
               {isFinite(kpi.usageMW.effect)
                 ? kpi.usageMW.effect.toFixed(2)
                 : '—'}
@@ -90,15 +90,16 @@ export default function RangeComparisons({ rangeA, rangeB }) {
             <td>
               {isFinite(kpi.ahiMW.p) ? kpi.ahiMW.p.toExponential(2) : '—'}
             </td>
-            <td>
+            <td title="Rank-biserial effect; positive means B tends to be larger">
               {isFinite(kpi.ahiMW.effect) ? kpi.ahiMW.effect.toFixed(2) : '—'}
             </td>
           </tr>
         </tbody>
       </table>
       <p style={{ opacity: 0.8 }}>
-        nA={kpi.nA}, nB={kpi.nB}. Mann–Whitney U p-values and rank-biserial
-        effects shown.
+        nA={kpi.nA}, nB={kpi.nB}. Mann–Whitney U p-values and signed
+        rank-biserial effects (positive means range B tends to be larger)
+        shown.
       </p>
     </div>
   );

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -710,14 +710,14 @@ export function mannWhitneyUTest(a, b) {
     z = sigma ? (U - mu) / sigma : 0;
     p = 2 * (1 - normalCdf(Math.abs(z)));
   }
-  // rank-biserial effect and approximate CI via proportion CI of CL = U/(n1*n2)
+  // rank-biserial effect and approximate CI via proportion CI of CL = P(B > A)
   const Npairs = n1 * n2;
-  const CL = U / Npairs; // using smaller U aligns with two-sided p; convert to rank-biserial by 1-2U/N
-  const effect = 1 - (2 * U) / Npairs;
+  const CL = Npairs ? U2 / Npairs : NaN;
+  const effect = isFinite(CL) ? 2 * CL - 1 : NaN;
   const { low: clLow, high: clHigh } = proportionCI(CL, Npairs);
   const effect_ci_low = 2 * clLow - 1;
   const effect_ci_high = 2 * clHigh - 1;
-  return { U, z, p, effect, effect_ci_low, effect_ci_high, method };
+  return { U, U1, U2, z, p, effect, effect_ci_low, effect_ci_high, method };
 }
 
 function binom(n, k) {

--- a/src/utils/stats.test.js
+++ b/src/utils/stats.test.js
@@ -146,7 +146,17 @@ describe('mannWhitneyUTest (exact small-n and ties)', () => {
     expect(res.method).toBe('exact');
     // Exact two-sided p = 2/6 = 0.333...
     expect(res.p).toBeLessThan(0.34);
-    expect(res.effect).toBeGreaterThan(0.9);
+    expect(res.effect).toBeCloseTo(1, 10);
+    expect(res.effect_ci_low).toBeLessThanOrEqual(res.effect_ci_high);
+    expect(res.effect).toBeGreaterThan(0);
+  });
+
+  it('flips sign when group ordering reverses', () => {
+    const a = [3, 4];
+    const b = [1, 2];
+    const res = mannWhitneyUTest(a, b);
+    expect(res.method).toBe('exact');
+    expect(res.effect).toBeCloseTo(-1, 10);
     expect(res.effect_ci_low).toBeLessThanOrEqual(res.effect_ci_high);
   });
 


### PR DESCRIPTION
## Summary
- orient the Mann–Whitney common-language probability to favour the second sample and expose signed rank-biserial effects
- expand statistical unit tests to check the new directional effect symmetry
- clarify range comparison and EPAP titration copy so positive effects read as the second group being larger

## Testing
- npx vitest run src/utils/stats.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de0ee316e4832f8c3d5cb54bee3602