### PR TITLE
fix: stabilize KM survival CI calculation

### DIFF
--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -908,16 +908,20 @@ export function kmSurvival(durations, z = 1.96) {
     }
     // log(-log S) CI
     if (S > 0 && S < 1) {
-      const se = Math.sqrt(cumGreenwood);
-      const loglog = Math.log(-Math.log(S));
-      const lo = Math.exp(-Math.exp(loglog + z * se));
-      const hi = Math.exp(-Math.exp(loglog - z * se));
-      lower.push(lo);
-      upper.push(hi);
-    } else {
-      lower.push(NaN);
-      upper.push(NaN);
+      const logS = Math.log(S);
+      const absLogS = Math.abs(logS);
+      if (absLogS > 1e-12 && Number.isFinite(absLogS)) {
+        const se = Math.sqrt(cumGreenwood) / absLogS;
+        const loglog = Math.log(-Math.log(S));
+        const lo = Math.exp(-Math.exp(loglog + z * se));
+        const hi = Math.exp(-Math.exp(loglog - z * se));
+        lower.push(lo);
+        upper.push(hi);
+        continue;
+      }
     }
+    lower.push(NaN);
+    upper.push(NaN);
   }
   return { times, survival, lower, upper };
 }

--- a/src/utils/stats.test.js
+++ b/src/utils/stats.test.js
@@ -54,6 +54,17 @@ describe('kmSurvival (Kaplan–Meier) uncensored', () => {
     expect(lower.length).toBe(times.length);
     expect(upper.length).toBe(times.length);
   });
+
+  it('produces log-log Greenwood CIs matching reference values', () => {
+    const durs = [1, 1, 2, 3];
+    const { lower, upper } = kmSurvival(durs);
+    expect(lower[0]).toBeCloseTo(0.0578428, 5);
+    expect(upper[0]).toBeCloseTo(0.844865, 5);
+    expect(lower[1]).toBeCloseTo(0.00894687, 5);
+    expect(upper[1]).toBeCloseTo(0.665331, 5);
+    expect(lower[2]).toBeNaN();
+    expect(upper[2]).toBeNaN();
+  });
 });
 
 describe('partialCorrelation (controls reduce confounding)', () => {


### PR DESCRIPTION
## Summary
- adjust the Kaplan–Meier survival log–log CI standard error to divide the Greenwood estimate by |log S| with boundary guards
- add a regression test that checks the CI values for a small uncensored sample
- ensure the ApneaEventStats survival plot test still renders with the updated CI band

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68de0f1e9514832fabefcd2c3a30368f