### PR TITLE
fix: ignore invalid usage nights in summary KPIs

### DIFF
--- a/src/App.worker.integration.test.jsx
+++ b/src/App.worker.integration.test.jsx
@@ -26,7 +26,7 @@ describe('Worker Integration Tests', () => {
     await userEvent.upload(input, [summary, details]);
 
     await waitFor(() => {
-      expect(screen.getByText(/Total nights analyzed/i)).toBeInTheDocument();
+      expect(screen.getByText(/Valid nights analyzed/i)).toBeInTheDocument();
     });
   });
 

--- a/src/components/SummaryAnalysis.jsx
+++ b/src/components/SummaryAnalysis.jsx
@@ -15,6 +15,8 @@ export default function SummaryAnalysis({ clusters = [] }) {
   const usage = summarizeUsage(data || []);
   const ahi = computeAHITrends(data || []);
   const epap = computeEPAPTrends(data || []);
+  const percent = (count, denom) =>
+    denom ? ((count / denom) * 100).toFixed(1) : '—';
   return (
     <div>
       <h2 id="usage-patterns">
@@ -23,9 +25,19 @@ export default function SummaryAnalysis({ clusters = [] }) {
       <table>
         <tbody>
           <tr>
-            <td>Total nights analyzed</td>
+            <td>Total nights provided</td>
             <td>{usage.totalNights}</td>
           </tr>
+          <tr>
+            <td>Valid nights analyzed</td>
+            <td>{usage.validNights}</td>
+          </tr>
+          {usage.invalidNights > 0 && (
+            <tr>
+              <td>Invalid nights excluded</td>
+              <td>{usage.invalidNights}</td>
+            </tr>
+          )}
           <tr>
             <td>Average usage per night</td>
             <td>{usage.avgHours.toFixed(2)} hours</td>
@@ -34,14 +46,14 @@ export default function SummaryAnalysis({ clusters = [] }) {
             <td>Nights ≥ 4 h usage</td>
             <td>
               {usage.nightsLong} (
-              {((usage.nightsLong / usage.totalNights) * 100).toFixed(1)}%)
+              {percent(usage.nightsLong, usage.validNights)}%)
             </td>
           </tr>
           <tr>
             <td>Nights &lt; 4 h usage</td>
             <td>
               {usage.nightsShort} (
-              {((usage.nightsShort / usage.totalNights) * 100).toFixed(1)}%)
+              {percent(usage.nightsShort, usage.validNights)}%)
             </td>
           </tr>
         </tbody>
@@ -113,7 +125,7 @@ export default function SummaryAnalysis({ clusters = [] }) {
             <td>Nights with AHI &gt; 5.0</td>
             <td>
               {ahi.nightsAHIover5} (
-              {((ahi.nightsAHIover5 / usage.totalNights) * 100).toFixed(1)}%)
+              {percent(ahi.nightsAHIover5, usage.validNights)}%)
             </td>
           </tr>
         </tbody>

--- a/src/utils/export.js
+++ b/src/utils/export.js
@@ -6,18 +6,20 @@ export function buildSummaryAggregatesCSV(summaryData = []) {
   const usage = summarizeUsage(summaryData);
   const ahi = computeAHITrends(summaryData);
   const epap = computeEPAPTrends(summaryData);
+  const pctNightsGe4h = usage.validNights
+    ? (usage.nightsLong / usage.validNights) * 100
+    : NaN;
   const rows = [
     ['total_nights', usage.totalNights],
+    ['valid_nights', usage.validNights],
+    ['invalid_nights', usage.invalidNights],
     ['avg_usage_hours', round(usage.avgHours, 3)],
     ['median_usage_hours', round(usage.medianHours, 3)],
     ['p25_usage_hours', round(usage.p25Hours, 3)],
     ['p75_usage_hours', round(usage.p75Hours, 3)],
     ['min_usage_hours', round(usage.minHours, 3)],
     ['max_usage_hours', round(usage.maxHours, 3)],
-    [
-      'pct_nights_ge_4h',
-      round((usage.nightsLong / usage.totalNights) * 100, 1),
-    ],
+    ['pct_nights_ge_4h', round(pctNightsGe4h, 1)],
     ['avg_AHI', round(ahi.avgAHI, 3)],
     ['median_AHI', round(ahi.medianAHI, 3)],
     ['p25_AHI', round(ahi.p25AHI, 3)],

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -144,14 +144,22 @@ export function computeApneaEventStats(details) {
 // Summarize nightly usage statistics from summary data rows
 export function summarizeUsage(data) {
   const totalNights = data.length;
-  const usageHours = data
-    .map((r) => parseDuration(r['Total Time']) / 3600)
-    .filter((h) => !isNaN(h));
+  const usageHours = [];
+  let invalidNights = 0;
+  for (const row of data) {
+    const hours = parseDuration(row['Total Time']) / 3600;
+    if (Number.isFinite(hours)) {
+      usageHours.push(hours);
+    } else {
+      invalidNights += 1;
+    }
+  }
+  const validNights = usageHours.length;
   const sumHours = usageHours.reduce((sum, h) => sum + h, 0);
-  const avgHours = totalNights ? sumHours / totalNights : NaN;
+  const avgHours = validNights ? sumHours / validNights : NaN;
   const nightsLong = usageHours.filter((h) => h >= 4).length;
   const nightsLong6 = usageHours.filter((h) => h >= 6).length;
-  const nightsShort = totalNights - nightsLong;
+  const nightsShort = usageHours.filter((h) => h < 4).length;
   let minHours = NaN,
     maxHours = NaN,
     medianHours = NaN,
@@ -176,6 +184,8 @@ export function summarizeUsage(data) {
   }
   return {
     totalNights,
+    validNights,
+    invalidNights,
     avgHours,
     nightsLong,
     nightsLong6,

--- a/src/utils/stats.test.js
+++ b/src/utils/stats.test.js
@@ -224,6 +224,8 @@ describe('summarizeUsage', () => {
     const data = [{ 'Total Time': '1:00:00' }, { 'Total Time': '3:00:00' }];
     const usage = summarizeUsage(data);
     expect(usage.totalNights).toBe(2);
+    expect(usage.validNights).toBe(2);
+    expect(usage.invalidNights).toBe(0);
     expect(usage.avgHours).toBe(2);
     expect(usage.nightsLong).toBe(0);
     expect(usage.nightsShort).toBe(2);
@@ -231,9 +233,26 @@ describe('summarizeUsage', () => {
     expect(usage.iqrHours).toBe(1);
   });
 
+  it('ignores invalid total time values when computing averages', () => {
+    const data = [
+      { 'Total Time': '01:30:00' },
+      { 'Total Time': 'bad' },
+      { 'Total Time': null },
+    ];
+    const usage = summarizeUsage(data);
+    expect(usage.totalNights).toBe(3);
+    expect(usage.validNights).toBe(1);
+    expect(usage.invalidNights).toBe(2);
+    expect(usage.avgHours).toBe(1.5);
+    expect(usage.nightsShort).toBe(1);
+    expect(usage.nightsLong).toBe(0);
+  });
+
   it('handles empty input', () => {
     const usage = summarizeUsage([]);
     expect(usage.totalNights).toBe(0);
+    expect(usage.validNights).toBe(0);
+    expect(usage.invalidNights).toBe(0);
     expect(Number.isNaN(usage.avgHours)).toBe(true);
     expect(Number.isNaN(usage.minHours)).toBe(true);
     expect(Number.isNaN(usage.maxHours)).toBe(true);


### PR DESCRIPTION
## Summary
- track valid versus invalid usage nights when summarizing nightly hours and exclude invalid values from averages and thresholds
- update the usage summary UI and CSV export to report the new counts and compute percentages from valid nights only
- extend tests with an invalid Total Time fixture and align the worker integration expectation with the new wording

## Testing
- npm test -- --run src/utils/stats.test.js src/App.worker.integration.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68de0f1d797c832fa0ca1b9a7b76ee99