### PR TITLE
refactor: modularize analytics processing and date controls

### DIFF
--- a/src/components/DateRangeControls.jsx
+++ b/src/components/DateRangeControls.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+function DateRangeControls({
+  quickRange,
+  onQuickRangeChange,
+  startValue,
+  endValue,
+  onStartChange,
+  onEndChange,
+  onReset,
+}) {
+  return (
+    <div className="date-filter">
+      <select
+        value={quickRange}
+        onChange={(e) => onQuickRangeChange(e.target.value)}
+        aria-label="Quick range"
+      >
+        <option value="all">All</option>
+        <option value="7">Last 7 days</option>
+        <option value="14">Last 14 days</option>
+        <option value="30">Last 30 days</option>
+        <option value="90">Last 90 days</option>
+        <option value="180">Last 180 days</option>
+        <option value="365">Last year</option>
+        <option value="1825">Last 5 years</option>
+        <option value="custom">Custom</option>
+      </select>
+      <input
+        type="date"
+        value={startValue}
+        onChange={(e) => onStartChange(e.target.value)}
+        aria-label="Start date"
+      />
+      <span>-</span>
+      <input
+        type="date"
+        value={endValue}
+        onChange={(e) => onEndChange(e.target.value)}
+        aria-label="End date"
+      />
+      {(startValue || endValue) && (
+        <button className="btn-ghost" onClick={onReset} aria-label="Reset date filter">
+          ×
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default DateRangeControls;

--- a/src/hooks/useAnalyticsProcessing.js
+++ b/src/hooks/useAnalyticsProcessing.js
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react';
+import {
+  clusterApneaEvents,
+  detectFalseNegatives,
+  computeClusterSeverity,
+} from '../utils/clustering';
+
+export function useAnalyticsProcessing(detailsData, clusterParams, fnOptions) {
+  const [apneaClusters, setApneaClusters] = useState([]);
+  const [falseNegatives, setFalseNegatives] = useState([]);
+  const [processingDetails, setProcessingDetails] = useState(false);
+
+  useEffect(() => {
+    if (!detailsData) {
+      setApneaClusters([]);
+      setFalseNegatives([]);
+      setProcessingDetails(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    let worker;
+
+    const finishProcessing = (clusters = [], negatives = []) => {
+      if (cancelled) return;
+      setApneaClusters(clusters);
+      setFalseNegatives(negatives);
+      setProcessingDetails(false);
+    };
+
+    const fallbackCompute = () => {
+      const apneaEvents = detailsData
+        .filter((r) => ['ClearAirway', 'Obstructive', 'Mixed'].includes(r['Event']))
+        .map((r) => ({
+          date: new Date(r['DateTime']),
+          durationSec: parseFloat(r['Data/Duration']),
+        }));
+      const flgEvents = detailsData
+        .filter((r) => r['Event'] === 'FLG')
+        .map((r) => ({
+          date: new Date(r['DateTime']),
+          level: parseFloat(r['Data/Duration']),
+        }));
+      const rawClusters = clusterApneaEvents(
+        apneaEvents,
+        flgEvents,
+        clusterParams.gapSec,
+        clusterParams.bridgeThreshold,
+        clusterParams.bridgeSec,
+        clusterParams.edgeEnter,
+        clusterParams.edgeExit,
+        10,
+        clusterParams.minDensity,
+      );
+      const validClusters = rawClusters
+        .filter((cl) => cl.count >= clusterParams.minCount)
+        .filter(
+          (cl) =>
+            cl.events.reduce((sum, e) => sum + e.durationSec, 0) >=
+            clusterParams.minTotalSec,
+        )
+        .filter((cl) => cl.durationSec <= clusterParams.maxClusterSec)
+        .map((cl) => ({ ...cl, severity: computeClusterSeverity(cl) }));
+
+      finishProcessing(validClusters, detectFalseNegatives(detailsData, fnOptions));
+    };
+
+    setProcessingDetails(true);
+
+    try {
+      // eslint-disable-next-line no-undef
+      worker = new Worker(new URL('../workers/analytics.worker.js', import.meta.url), {
+        type: 'module',
+      });
+      worker.onmessage = (evt) => {
+        if (cancelled) return;
+        const { ok, data, error } = evt.data || {};
+        if (ok) {
+          const rawClusters = data.clusters || [];
+          const validClusters = rawClusters
+            .filter((cl) => cl.count >= clusterParams.minCount)
+            .filter(
+              (cl) =>
+                cl.events.reduce((sum, e) => sum + e.durationSec, 0) >=
+                clusterParams.minTotalSec,
+            )
+            .filter((cl) => cl.durationSec <= clusterParams.maxClusterSec)
+            .map((cl) => ({ ...cl, severity: computeClusterSeverity(cl) }));
+          finishProcessing(validClusters, data.falseNegatives || []);
+        } else {
+          console.warn('Analytics worker error:', error);
+          fallbackCompute();
+        }
+      };
+      worker.postMessage({
+        action: 'analyzeDetails',
+        payload: { detailsData, params: clusterParams, fnOptions },
+      });
+    } catch (err) {
+      console.warn('Worker unavailable, using fallback', err);
+      fallbackCompute();
+    }
+
+    return () => {
+      cancelled = true;
+      try {
+        worker && worker.terminate && worker.terminate();
+      } catch {
+        // ignore termination errors
+      }
+      setProcessingDetails(false);
+    };
+  }, [detailsData, clusterParams, fnOptions]);
+
+  return { apneaClusters, falseNegatives, processingDetails };
+}

--- a/src/hooks/useAnalyticsProcessing.test.js
+++ b/src/hooks/useAnalyticsProcessing.test.js
@@ -1,0 +1,122 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useAnalyticsProcessing } from './useAnalyticsProcessing';
+
+const baseParams = {
+  gapSec: 120,
+  bridgeThreshold: 0.7,
+  bridgeSec: 90,
+  minCount: 3,
+  minTotalSec: 60,
+  maxClusterSec: 600,
+  minDensity: 0,
+  edgeEnter: 2,
+  edgeExit: 1,
+};
+
+const fnOptions = {
+  flThreshold: 0.7,
+  confidenceMin: 0.9,
+  gapSec: 60,
+  minDurationSec: 60,
+};
+
+const DETAILS_DATA = [
+  {
+    Event: 'ClearAirway',
+    DateTime: '2024-01-01T00:00:00',
+    'Data/Duration': '30',
+  },
+  {
+    Event: 'Obstructive',
+    DateTime: '2024-01-01T00:04:00',
+    'Data/Duration': '25',
+  },
+  {
+    Event: 'Mixed',
+    DateTime: '2024-01-01T00:07:00',
+    'Data/Duration': '20',
+  },
+  {
+    Event: 'FLG',
+    DateTime: '2024-01-01T00:07:30',
+    'Data/Duration': '0.9',
+  },
+];
+
+describe('useAnalyticsProcessing', () => {
+  const originalWorker = global.Worker;
+
+  afterEach(() => {
+    global.Worker = originalWorker;
+  });
+
+  it('uses the analytics worker when available', async () => {
+    class MockWorker {
+      postMessage() {
+        setTimeout(() => {
+          this.onmessage?.({
+            data: {
+              ok: true,
+              data: {
+                clusters: [
+                  {
+                    count: 3,
+                    durationSec: 120,
+                    events: [
+                      {
+                        durationSec: 30,
+                        date: new Date('2024-01-01T00:00:00Z'),
+                      },
+                      {
+                        durationSec: 45,
+                        date: new Date('2024-01-01T00:03:00Z'),
+                      },
+                      {
+                        durationSec: 45,
+                        date: new Date('2024-01-01T00:06:00Z'),
+                      },
+                    ],
+                  },
+                ],
+                falseNegatives: [{ id: 'fn-1' }],
+              },
+            },
+          });
+        }, 0);
+      }
+      terminate() {}
+    }
+    global.Worker = MockWorker;
+
+    const { result } = renderHook(() =>
+      useAnalyticsProcessing(DETAILS_DATA, baseParams, fnOptions),
+    );
+
+    await waitFor(() => {
+      expect(result.current.processingDetails).toBe(false);
+      expect(result.current.apneaClusters).toHaveLength(1);
+    });
+
+    expect(result.current.falseNegatives).toHaveLength(1);
+    expect(result.current.apneaClusters[0]).toHaveProperty('severity');
+  });
+
+  it('falls back to in-thread processing when workers fail', async () => {
+    global.Worker = vi.fn(() => {
+      throw new Error('no worker');
+    });
+
+    const { result } = renderHook(() =>
+      useAnalyticsProcessing(DETAILS_DATA, baseParams, fnOptions),
+    );
+
+    await waitFor(() => {
+      expect(result.current.processingDetails).toBe(false);
+      expect(Array.isArray(result.current.apneaClusters)).toBe(true);
+    });
+
+    expect(Array.isArray(result.current.falseNegatives)).toBe(true);
+    expect(global.Worker).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useDateRangeFilter.js
+++ b/src/hooks/useDateRangeFilter.js
@@ -1,0 +1,103 @@
+import { useCallback, useMemo, useState } from 'react';
+
+const DEFAULT_FILTER = { start: null, end: null };
+
+export function useDateRangeFilter(summaryData) {
+  const [dateFilter, setDateFilter] = useState(DEFAULT_FILTER);
+  const [quickRange, setQuickRange] = useState('all');
+
+  const latestDate = useMemo(() => {
+    if (!summaryData || !summaryData.length) return new Date();
+    const dateCol = Object.keys(summaryData[0]).find((c) => /date/i.test(c));
+    if (!dateCol) return new Date();
+    return (
+      summaryData.reduce((max, r) => {
+        const d = new Date(r[dateCol]);
+        return !max || d > max ? d : max;
+      }, null) || new Date()
+    );
+  }, [summaryData]);
+
+  const parseDate = useCallback((val) => {
+    if (!val) return null;
+    const d = new Date(val);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }, []);
+
+  const formatDate = useCallback((d) => {
+    if (!(d instanceof Date) || Number.isNaN(d.getTime())) return '';
+    const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+    return local.toISOString().slice(0, 10);
+  }, []);
+
+  const applyDateFilter = useCallback((value) => {
+    if (!value || (!value.start && !value.end)) {
+      setQuickRange('all');
+      setDateFilter({ ...DEFAULT_FILTER });
+      return;
+    }
+    setQuickRange('custom');
+    setDateFilter({
+      start: value.start ?? null,
+      end: value.end ?? null,
+    });
+  }, []);
+
+  const handleQuickRangeChange = useCallback(
+    (val) => {
+      setQuickRange(val);
+      if (val === 'all') {
+        setDateFilter({ ...DEFAULT_FILTER });
+        return;
+      }
+      if (val === 'custom') return;
+      const days = parseInt(val, 10);
+      if (!Number.isNaN(days)) {
+        const end = latestDate;
+        const start = new Date(end);
+        start.setDate(start.getDate() - (days - 1));
+        setDateFilter({ start, end });
+      }
+    },
+    [latestDate],
+  );
+
+  const handleStartChange = useCallback(
+    (val) => {
+      setQuickRange('custom');
+      setDateFilter((prev) => ({
+        ...prev,
+        start: parseDate(val),
+      }));
+    },
+    [parseDate],
+  );
+
+  const handleEndChange = useCallback(
+    (val) => {
+      setQuickRange('custom');
+      setDateFilter((prev) => ({
+        ...prev,
+        end: parseDate(val),
+      }));
+    },
+    [parseDate],
+  );
+
+  const resetDateFilter = useCallback(() => {
+    setQuickRange('all');
+    setDateFilter({ ...DEFAULT_FILTER });
+  }, []);
+
+  return {
+    dateFilter,
+    quickRange,
+    latestDate,
+    handleQuickRangeChange,
+    handleStartChange,
+    handleEndChange,
+    resetDateFilter,
+    formatDate,
+    setDateFilter: applyDateFilter,
+  };
+}

--- a/src/hooks/useGuideControls.js
+++ b/src/hooks/useGuideControls.js
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const GUIDE_MAP = {
+  overview: 'overview-dashboard',
+  'usage-patterns': 'usage-patterns',
+  'ahi-trends': 'ahi-trends',
+  'pressure-settings': 'pressure-correlation-epap',
+  'apnea-characteristics': 'apnea-event-characteristics-details-csv',
+  'clustered-apnea': 'clustered-apnea-events-details-csv',
+  'false-negatives': 'potential-false-negatives-details-csv',
+  'raw-data-explorer': 'raw-data-explorer',
+  'range-compare': 'range-comparisons-a-vs-b',
+};
+
+export function useGuideControls(activeId) {
+  const [guideOpen, setGuideOpen] = useState(false);
+  const [guideAnchor, setGuideAnchor] = useState('');
+
+  const openGuide = useCallback((anchor = '') => {
+    setGuideAnchor(anchor);
+    setGuideOpen(true);
+  }, []);
+
+  const openGuideForActive = useCallback(() => {
+    const anchor = GUIDE_MAP[activeId] || '';
+    openGuide(anchor);
+  }, [activeId, openGuide]);
+
+  const closeGuide = useCallback(() => setGuideOpen(false), []);
+
+  useEffect(() => {
+    const handler = (e) => {
+      const anchor = e?.detail?.anchor || '';
+      openGuide(anchor);
+    };
+    window.addEventListener('open-guide', handler);
+    return () => window.removeEventListener('open-guide', handler);
+  }, [openGuide]);
+
+  return { guideOpen, guideAnchor, openGuideForActive, openGuide, closeGuide };
+}

--- a/src/hooks/useModalState.js
+++ b/src/hooks/useModalState.js
@@ -1,0 +1,10 @@
+import { useCallback, useState } from 'react';
+
+export function useModalState(initial = false) {
+  const [isOpen, setIsOpen] = useState(initial);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  return { isOpen, open, close, set: setIsOpen };
+}


### PR DESCRIPTION
## Summary
- extract the analytics worker/fallback flow into a reusable `useAnalyticsProcessing` hook and wire `App.jsx` to its outputs
- factor the header date controls into a dedicated hook/component and lift guide/import state into focused hooks
- add coverage for the analytics hook to ensure worker and fallback paths behave as expected

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68deeed4978c832fab9c74a01abea107