### PR TITLE
refactor: rely on shared cluster finalizer

### DIFF
--- a/src/App.analyticsFallback.test.jsx
+++ b/src/App.analyticsFallback.test.jsx
@@ -1,0 +1,111 @@
+import { render, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+
+const summaryData = [{ Date: '2025-06-01', 'Total Time': '08:00:00' }];
+const detailsData = [
+  {
+    Event: 'ClearAirway',
+    DateTime: '2025-06-01T00:00:00',
+    'Data/Duration': '30',
+  },
+  {
+    Event: 'ClearAirway',
+    DateTime: '2025-06-01T00:00:40',
+    'Data/Duration': '25',
+  },
+  {
+    Event: 'ClearAirway',
+    DateTime: '2025-06-01T00:01:10',
+    'Data/Duration': '20',
+  },
+];
+
+vi.mock('./utils/analytics', async () => {
+  const actual = await vi.importActual('./utils/analytics');
+  return {
+    ...actual,
+    finalizeClusters: vi.fn(actual.finalizeClusters),
+  };
+});
+
+vi.mock('./hooks/useCsvFiles', () => ({
+  useCsvFiles: () => ({
+    summaryData,
+    detailsData,
+    loadingSummary: false,
+    summaryProgress: 0,
+    summaryProgressMax: 0,
+    loadingDetails: false,
+    detailsProgress: 0,
+    detailsProgressMax: 0,
+    onSummaryFile: vi.fn(),
+    onDetailsFile: vi.fn(),
+    setSummaryData: vi.fn(),
+    setDetailsData: vi.fn(),
+    error: null,
+  }),
+}));
+
+vi.mock('./hooks/useSessionManager', () => ({
+  useSessionManager: () => ({
+    handleLoadSaved: vi.fn(),
+    handleExportJson: vi.fn(),
+    importSessionFile: vi.fn(),
+  }),
+}));
+
+vi.mock('./components/UsagePatternsCharts', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('App fallback analytics', () => {
+  const originalWorker = global.Worker;
+
+  afterEach(async () => {
+    global.Worker = originalWorker;
+    const analytics = await import('./utils/analytics');
+    analytics.finalizeClusters.mockClear();
+  });
+
+  it('uses finalizeClusters when the analytics worker returns an error', async () => {
+    const analytics = await import('./utils/analytics');
+    const mockClusters = [
+      {
+        start: new Date('2025-06-01T00:00:00Z'),
+        end: new Date('2025-06-01T00:05:00Z'),
+        durationSec: 300,
+        count: 3,
+        severity: 4.2,
+        events: [],
+      },
+    ];
+    analytics.finalizeClusters.mockReturnValueOnce(mockClusters);
+
+    class MockWorker {
+      constructor(url) {
+        this.url = typeof url === 'string' ? url : url?.href || '';
+      }
+
+      postMessage() {
+        if (this.url.includes('analytics.worker')) {
+          setTimeout(() => {
+            this.onmessage?.({ ok: false, data: null, error: 'fail' });
+          }, 0);
+        }
+      }
+
+      terminate() {}
+    }
+
+    global.Worker = MockWorker;
+
+    const { default: App } = await import('./App');
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(analytics.finalizeClusters).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/App.analyticsWorker.test.jsx
+++ b/src/App.analyticsWorker.test.jsx
@@ -1,0 +1,119 @@
+import { render, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+
+const summaryData = [{ Date: '2025-06-01', 'Total Time': '08:00:00' }];
+const detailsData = [
+  {
+    Event: 'ClearAirway',
+    DateTime: '2025-06-01T00:00:00',
+    'Data/Duration': '30',
+  },
+];
+
+vi.mock('./utils/analytics', async () => {
+  const actual = await vi.importActual('./utils/analytics');
+  return {
+    ...actual,
+    finalizeClusters: vi.fn(actual.finalizeClusters),
+  };
+});
+
+vi.mock('./hooks/useCsvFiles', () => ({
+  useCsvFiles: () => ({
+    summaryData,
+    detailsData,
+    loadingSummary: false,
+    summaryProgress: 0,
+    summaryProgressMax: 0,
+    loadingDetails: false,
+    detailsProgress: 0,
+    detailsProgressMax: 0,
+    onSummaryFile: vi.fn(),
+    onDetailsFile: vi.fn(),
+    setSummaryData: vi.fn(),
+    setDetailsData: vi.fn(),
+    error: null,
+  }),
+}));
+
+vi.mock('./hooks/useSessionManager', () => ({
+  useSessionManager: () => ({
+    handleLoadSaved: vi.fn(),
+    handleExportJson: vi.fn(),
+    importSessionFile: vi.fn(),
+  }),
+}));
+
+vi.mock('./components/UsagePatternsCharts', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock('./components/DocsModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock('./components/DataImportModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('App analytics worker integration', () => {
+  const originalWorker = global.Worker;
+
+  afterEach(async () => {
+    global.Worker = originalWorker;
+    const analytics = await import('./utils/analytics');
+    analytics.finalizeClusters.mockClear();
+  });
+
+  it('relies on worker-supplied clusters without re-finalizing them', async () => {
+    const workerInstances = [];
+
+    class MockWorker {
+      constructor(url) {
+        this.url = typeof url === 'string' ? url : url?.href || '';
+        this.onmessage = null;
+        workerInstances.push(this);
+      }
+
+      postMessage() {
+        if (this.url.includes('analytics.worker')) {
+          setTimeout(() => {
+            this.onmessage?.({
+              data: {
+                ok: true,
+                data: {
+                  clusters: [
+                    {
+                      id: 'cluster-1',
+                      count: 3,
+                      severity: 'moderate',
+                    },
+                  ],
+                  falseNegatives: [],
+                },
+              },
+            });
+          }, 0);
+        }
+      }
+
+      terminate() {}
+    }
+
+    global.Worker = MockWorker;
+
+    const { default: App } = await import('./App');
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(workerInstances.length).toBeGreaterThan(0);
+    });
+
+    const analytics = await import('./utils/analytics');
+    expect(analytics.finalizeClusters).not.toHaveBeenCalled();
+  });
+});

--- a/src/App.worker.integration.test.jsx
+++ b/src/App.worker.integration.test.jsx
@@ -1,3 +1,18 @@
+import { vi } from 'vitest';
+
+vi.mock('./utils/analytics', async () => {
+  const actual = await vi.importActual('./utils/analytics');
+  return {
+    ...actual,
+    finalizeClusters: vi.fn(actual.finalizeClusters),
+  };
+});
+
+vi.mock('./components/UsagePatternsCharts', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -13,7 +28,7 @@ describe('Worker Integration Tests', () => {
   it('parses CSVs via worker and displays summary analysis', async () => {
     render(<App />);
     const summary = new File(
-      ['Night,Data/Duration\n2025-06-01,8'],
+      ['Date,Total Time\n2025-06-01,08:00:00'],
       'summary.csv',
       { type: 'text/csv' },
     );
@@ -54,4 +69,5 @@ describe('Worker Integration Tests', () => {
     });
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
+
 });

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -1,0 +1,46 @@
+import { computeClusterSeverity } from './clustering';
+
+/**
+ * Normalize raw apnea clusters by applying configured filters and computing
+ * severity scores. This ensures consistent presentation between worker and
+ * fallback analytics flows.
+ *
+ * @param {Array} rawClusters
+ * @param {{ minCount?: number, minTotalSec?: number, maxClusterSec?: number }} params
+ * @returns {Array}
+ */
+export function finalizeClusters(rawClusters, params = {}) {
+  const {
+    minCount = 0,
+    minTotalSec = 0,
+    maxClusterSec = Number.POSITIVE_INFINITY,
+  } = params;
+
+  const maxDuration = Number.isFinite(maxClusterSec)
+    ? maxClusterSec
+    : Number.POSITIVE_INFINITY;
+
+  return (rawClusters || [])
+    .map((cluster) => {
+      const totalDuration = (cluster?.events || []).reduce(
+        (sum, event) => sum + (event?.durationSec || 0),
+        0,
+      );
+      const duration =
+        typeof cluster?.durationSec === 'number'
+          ? cluster.durationSec
+          : totalDuration;
+      return {
+        cluster,
+        totalDuration,
+        duration,
+      };
+    })
+    .filter(({ cluster }) => Number(cluster?.count ?? 0) >= minCount)
+    .filter(({ totalDuration }) => totalDuration >= minTotalSec)
+    .filter(({ duration }) => duration <= maxDuration)
+    .map(({ cluster }) => ({
+      ...cluster,
+      severity: computeClusterSeverity(cluster),
+    }));
+}

--- a/src/utils/analytics.test.js
+++ b/src/utils/analytics.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { finalizeClusters } from './analytics';
+
+const baseDate = new Date('2025-01-01T00:00:00Z');
+
+function makeEvent(offsetSec, durationSec) {
+  return {
+    date: new Date(baseDate.getTime() + offsetSec * 1000),
+    durationSec,
+  };
+}
+
+describe('finalizeClusters', () => {
+  it('filters clusters and adds severity metadata', () => {
+    const raw = [
+      {
+        start: baseDate,
+        end: new Date(baseDate.getTime() + 200 * 1000),
+        durationSec: 200,
+        count: 3,
+        events: [makeEvent(0, 30), makeEvent(40, 25), makeEvent(80, 35)],
+      },
+      {
+        start: baseDate,
+        end: new Date(baseDate.getTime() + 50 * 1000),
+        durationSec: 50,
+        count: 2,
+        events: [makeEvent(0, 10), makeEvent(20, 5)],
+      },
+      {
+        start: baseDate,
+        end: new Date(baseDate.getTime() + 400 * 1000),
+        durationSec: 400,
+        count: 3,
+        events: [makeEvent(0, 10), makeEvent(200, 10), makeEvent(380, 10)],
+      },
+    ];
+
+    const finalized = finalizeClusters(raw, {
+      minCount: 3,
+      minTotalSec: 60,
+      maxClusterSec: 300,
+    });
+
+    expect(finalized).toHaveLength(1);
+    expect(finalized[0]).toMatchObject({ count: 3, durationSec: 200 });
+    expect(finalized[0].severity).toBeGreaterThan(0);
+  });
+
+  it('handles undefined arrays gracefully', () => {
+    expect(finalizeClusters(undefined)).toEqual([]);
+  });
+});

--- a/src/workers/analytics.worker.js
+++ b/src/workers/analytics.worker.js
@@ -4,6 +4,7 @@ import {
   clusterApneaEvents,
   detectFalseNegatives,
 } from '../utils/clustering.js';
+import { finalizeClusters } from '../utils/analytics.js';
 
 self.onmessage = (e) => {
   const { action, payload } = e.data || {};
@@ -38,7 +39,10 @@ self.onmessage = (e) => {
       const fns = detectFalseNegatives(detailsData, fnOptions || {});
       self.postMessage({
         ok: true,
-        data: { clusters: rawClusters, falseNegatives: fns },
+        data: {
+          clusters: finalizeClusters(rawClusters, params),
+          falseNegatives: fns,
+        },
       });
     } catch (err) {
       self.postMessage({

--- a/src/workers/analytics.worker.test.js
+++ b/src/workers/analytics.worker.test.js
@@ -1,0 +1,82 @@
+import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest';
+
+const finalizeClustersMock = vi.fn();
+const clusterApneaEventsMock = vi.fn();
+const detectFalseNegativesMock = vi.fn();
+
+vi.mock('../utils/analytics.js', () => ({
+  finalizeClusters: finalizeClustersMock,
+}));
+
+vi.mock('../utils/clustering.js', () => ({
+  clusterApneaEvents: clusterApneaEventsMock,
+  detectFalseNegatives: detectFalseNegativesMock,
+}));
+
+describe('analytics.worker', () => {
+  beforeEach(() => {
+    finalizeClustersMock.mockReset();
+    clusterApneaEventsMock.mockReset();
+    detectFalseNegativesMock.mockReset();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete global.self;
+  });
+
+  it('finalizes clusters before posting results', async () => {
+    const postedClusters = [{ id: 'final', severity: 'high' }];
+    const rawClusters = [{ id: 'raw', count: 3 }];
+
+    finalizeClustersMock.mockReturnValue(postedClusters);
+    clusterApneaEventsMock.mockReturnValue(rawClusters);
+    detectFalseNegativesMock.mockReturnValue(['fn']);
+
+    const postMessage = vi.fn();
+    global.self = { postMessage };
+
+    await import('./analytics.worker.js');
+
+    expect(typeof global.self.onmessage).toBe('function');
+
+    const payload = {
+      action: 'analyzeDetails',
+      payload: {
+        detailsData: [
+          {
+            Event: 'ClearAirway',
+            DateTime: '2025-06-01T00:00:00',
+            'Data/Duration': '12',
+          },
+          {
+            Event: 'FLG',
+            DateTime: '2025-06-01T00:00:12',
+            'Data/Duration': '0.8',
+          },
+        ],
+        params: {
+          gapSec: 120,
+          bridgeThreshold: 0.5,
+          bridgeSec: 30,
+          edgeEnter: 1,
+          edgeExit: 0.3,
+          minDensity: 0.2,
+        },
+        fnOptions: { foo: 'bar' },
+      },
+    };
+
+    global.self.onmessage({ data: payload });
+
+    expect(clusterApneaEventsMock).toHaveBeenCalled();
+    expect(finalizeClustersMock).toHaveBeenCalledWith(rawClusters, payload.payload.params);
+    expect(detectFalseNegativesMock).toHaveBeenCalledWith(payload.payload.detailsData, {
+      foo: 'bar',
+    });
+    expect(postMessage).toHaveBeenCalledWith({
+      ok: true,
+      data: { clusters: postedClusters, falseNegatives: ['fn'] },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- stop re-running finalizeClusters on clusters returned by the analytics worker so the worker output is trusted as-is
- add coverage proving the worker finalizes clusters and the app does not reapply the helper when the worker succeeds

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68deeef99bc8832fbc71ae8497d97629