### PR TITLE
refactor: modularize analytics flow and header controls

### DIFF
--- a/src/App.analyticsWorker.test.jsx
+++ b/src/App.analyticsWorker.test.jsx
@@ -75,10 +75,12 @@ describe('App analytics worker integration', () => {
       constructor(url) {
         this.url = typeof url === 'string' ? url : url?.href || '';
         this.onmessage = null;
+        this.messages = [];
         workerInstances.push(this);
       }
 
-      postMessage() {
+      postMessage(message) {
+        this.messages.push(message);
         if (this.url.includes('analytics.worker')) {
           setTimeout(() => {
             this.onmessage?.({
@@ -115,5 +117,8 @@ describe('App analytics worker integration', () => {
 
     const analytics = await import('./utils/analytics');
     expect(analytics.finalizeClusters).not.toHaveBeenCalled();
+    expect(workerInstances[0].messages[0]).toMatchObject({
+      action: 'analyzeDetails',
+    });
   });
 });

--- a/src/components/DateRangeControls.jsx
+++ b/src/components/DateRangeControls.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+function DateRangeControls({
+  quickRange,
+  onQuickRangeChange,
+  dateFilter,
+  onDateFilterChange,
+  onCustomRange,
+  onReset,
+  parseDate,
+  formatDate,
+}) {
+  return (
+    <div className="date-filter">
+      <select
+        value={quickRange}
+        onChange={(e) => onQuickRangeChange(e.target.value)}
+        aria-label="Quick range"
+      >
+        <option value="all">All</option>
+        <option value="7">Last 7 days</option>
+        <option value="14">Last 14 days</option>
+        <option value="30">Last 30 days</option>
+        <option value="90">Last 90 days</option>
+        <option value="180">Last 180 days</option>
+        <option value="365">Last year</option>
+        <option value="1825">Last 5 years</option>
+        <option value="custom">Custom</option>
+      </select>
+      <input
+        type="date"
+        value={formatDate(dateFilter.start)}
+        onChange={(e) => {
+          onCustomRange();
+          const value = parseDate(e.target.value);
+          onDateFilterChange((prev) => ({ ...prev, start: value }));
+        }}
+        aria-label="Start date"
+      />
+      <span>-</span>
+      <input
+        type="date"
+        value={formatDate(dateFilter.end)}
+        onChange={(e) => {
+          onCustomRange();
+          const value = parseDate(e.target.value);
+          onDateFilterChange((prev) => ({ ...prev, end: value }));
+        }}
+        aria-label="End date"
+      />
+      {(dateFilter.start || dateFilter.end) && (
+        <button className="btn-ghost" onClick={onReset} aria-label="Reset date filter">
+          ×
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default DateRangeControls;

--- a/src/hooks/useAnalyticsProcessing.js
+++ b/src/hooks/useAnalyticsProcessing.js
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+import {
+  clusterApneaEvents,
+  detectFalseNegatives,
+} from '../utils/clustering';
+import { finalizeClusters } from '../utils/analytics';
+
+export function useAnalyticsProcessing(detailsData, clusterParams, fnOptions) {
+  const [apneaClusters, setApneaClusters] = useState([]);
+  const [falseNegatives, setFalseNegatives] = useState([]);
+  const [processing, setProcessing] = useState(false);
+
+  useEffect(() => {
+    if (!detailsData || !detailsData.length) {
+      setApneaClusters([]);
+      setFalseNegatives([]);
+      setProcessing(false);
+      return undefined;
+    }
+
+    setProcessing(true);
+    let cancelled = false;
+    let worker;
+
+    const fallbackCompute = () => {
+      if (cancelled) return;
+      const apneaEvents = detailsData
+        .filter((r) => ['ClearAirway', 'Obstructive', 'Mixed'].includes(r['Event']))
+        .map((r) => ({
+          date: new Date(r['DateTime']),
+          durationSec: parseFloat(r['Data/Duration']),
+        }));
+      const flgEvents = detailsData
+        .filter((r) => r['Event'] === 'FLG')
+        .map((r) => ({
+          date: new Date(r['DateTime']),
+          level: parseFloat(r['Data/Duration']),
+        }));
+      const rawClusters = clusterApneaEvents(
+        apneaEvents,
+        flgEvents,
+        clusterParams.gapSec,
+        clusterParams.bridgeThreshold,
+        clusterParams.bridgeSec,
+        clusterParams.edgeEnter,
+        clusterParams.edgeExit,
+        10,
+        clusterParams.minDensity,
+      );
+      const validClusters = finalizeClusters(rawClusters, clusterParams);
+      setApneaClusters(validClusters);
+      setFalseNegatives(detectFalseNegatives(detailsData, fnOptions));
+      setProcessing(false);
+    };
+
+    try {
+      // eslint-disable-next-line no-undef
+      worker = new Worker(new URL('../workers/analytics.worker.js', import.meta.url), {
+        type: 'module',
+      });
+      worker.onmessage = (evt) => {
+        if (cancelled) return;
+        const { ok, data, error } = evt.data || {};
+        if (ok) {
+          setApneaClusters(data.clusters || []);
+          setFalseNegatives(data.falseNegatives || []);
+          setProcessing(false);
+        } else {
+          console.warn('Analytics worker error:', error);
+          fallbackCompute();
+        }
+      };
+      worker.postMessage({
+        action: 'analyzeDetails',
+        payload: { detailsData, params: clusterParams, fnOptions },
+      });
+    } catch (err) {
+      console.warn('Worker unavailable, using fallback', err);
+      fallbackCompute();
+    }
+
+    return () => {
+      cancelled = true;
+      try {
+        worker && worker.terminate && worker.terminate();
+      } catch {
+        // ignore termination errors
+      }
+      setProcessing(false);
+    };
+  }, [detailsData, clusterParams, fnOptions]);
+
+  return { apneaClusters, falseNegatives, processing };
+}

--- a/src/hooks/useDateRangeFilter.js
+++ b/src/hooks/useDateRangeFilter.js
@@ -1,0 +1,68 @@
+import { useCallback, useMemo, useState } from 'react';
+
+export function useDateRangeFilter(summaryData) {
+  const [dateFilter, setDateFilter] = useState({ start: null, end: null });
+  const [quickRange, setQuickRange] = useState('all');
+
+  const latestDate = useMemo(() => {
+    if (!summaryData || !summaryData.length) return new Date();
+    const dateCol = Object.keys(summaryData[0] || {}).find((c) => /date/i.test(c));
+    if (!dateCol) return new Date();
+    return (
+      summaryData.reduce((max, row) => {
+        const d = new Date(row[dateCol]);
+        return !max || d > max ? d : max;
+      }, null) || new Date()
+    );
+  }, [summaryData]);
+
+  const handleQuickRangeChange = useCallback(
+    (val) => {
+      setQuickRange(val);
+      if (val === 'all') {
+        setDateFilter({ start: null, end: null });
+      } else if (val !== 'custom') {
+        const days = parseInt(val, 10);
+        if (!Number.isNaN(days)) {
+          const end = latestDate;
+          const start = new Date(end);
+          start.setDate(start.getDate() - (days - 1));
+          setDateFilter({ start, end });
+        }
+      }
+    },
+    [latestDate, setDateFilter, setQuickRange],
+  );
+
+  const parseDate = useCallback((val) => {
+    if (!val) return null;
+    const d = new Date(val);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }, []);
+
+  const formatDate = useCallback((d) => {
+    if (!(d instanceof Date) || Number.isNaN(d.getTime())) return '';
+    const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+    return local.toISOString().slice(0, 10);
+  }, []);
+
+  const selectCustomRange = useCallback(() => {
+    setQuickRange('custom');
+  }, [setQuickRange]);
+
+  const resetDateFilter = useCallback(() => {
+    setQuickRange('all');
+    setDateFilter({ start: null, end: null });
+  }, [setDateFilter, setQuickRange]);
+
+  return {
+    dateFilter,
+    setDateFilter,
+    quickRange,
+    handleQuickRangeChange,
+    parseDate,
+    formatDate,
+    selectCustomRange,
+    resetDateFilter,
+  };
+}

--- a/src/hooks/useGuide.js
+++ b/src/hooks/useGuide.js
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export function useGuide(activeId) {
+  const guideMap = useMemo(
+    () => ({
+      overview: 'overview-dashboard',
+      'usage-patterns': 'usage-patterns',
+      'ahi-trends': 'ahi-trends',
+      'pressure-settings': 'pressure-correlation-epap',
+      'apnea-characteristics': 'apnea-event-characteristics-details-csv',
+      'clustered-apnea': 'clustered-apnea-events-details-csv',
+      'false-negatives': 'potential-false-negatives-details-csv',
+      'raw-data-explorer': 'raw-data-explorer',
+      'range-compare': 'range-comparisons-a-vs-b',
+    }),
+    [],
+  );
+
+  const [guideOpen, setGuideOpen] = useState(false);
+  const [guideAnchor, setGuideAnchor] = useState('');
+
+  const openGuide = useCallback((anchor = '') => {
+    setGuideAnchor(anchor);
+    setGuideOpen(true);
+  }, []);
+
+  const openGuideForActive = useCallback(() => {
+    const anchor = guideMap[activeId] || '';
+    openGuide(anchor);
+  }, [activeId, guideMap, openGuide]);
+
+  const closeGuide = useCallback(() => setGuideOpen(false), []);
+
+  useEffect(() => {
+    const handler = (event) => {
+      const anchor = event?.detail?.anchor || '';
+      openGuide(anchor);
+    };
+    window.addEventListener('open-guide', handler);
+    return () => window.removeEventListener('open-guide', handler);
+  }, [openGuide]);
+
+  return { guideOpen, guideAnchor, openGuideForActive, closeGuide };
+}

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -1,0 +1,10 @@
+import { useCallback, useState } from 'react';
+
+export function useModal(initial = false) {
+  const [isOpen, setIsOpen] = useState(initial);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  return { isOpen, open, close };
+}


### PR DESCRIPTION
## Summary
- extract analytics worker handling into a reusable `useAnalyticsProcessing` hook and wire it into `App`
- introduce date range and guide management hooks/components to simplify `App.jsx`
- update analytics-related tests to assert worker payloads after the refactor

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e2e2615c98832f8ca7813f7580552d