### PR TITLE
feat: add STL decomposition visualizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ If `BASE_URL` is unset, the build defaults to `/oscar-export-analyzer/`.
 ## Feature Tour
 
 - **Overview Dashboard** – At‑a‑glance KPIs for adherence and AHI with small trend sparklines.
-- **Usage Patterns** – Time‑series, histograms, and calendar heatmaps reveal how consistently therapy is being used. A 7‑night and 30‑night rolling average quantify medium‑ and long‑term trends.
-- **AHI Trends** – Breaks AHI into nightly values with optional obstructive/central stacking. Histogram and QQ plots test whether AHI is normally distributed.
+- **Usage Patterns** – Time‑series, histograms, STL trend/seasonal/residual panes, and calendar heatmaps reveal how consistently therapy is being used. A 7‑night and 30‑night rolling average quantify medium‑ and long‑term trends while the decomposition highlights weekday habits and outlier nights.
+- **AHI Trends** – Breaks AHI into nightly values with optional obstructive/central stacking. Histogram and QQ plots test whether AHI is normally distributed, and a weekly STL decomposition separates the smooth trend from recurring seasonal swings and noisy residuals.
 - **Pressure & Correlation** – Investigates how exhalation pressure (EPAP) relates to AHI. Scatter plots, LOESS curves, and correlation matrices support hypothesis generation.
 - **Range Comparison** – Select two date ranges to compute deltas, `p`‑values, and effect sizes for usage and AHI.
 - **Event Exploration** – Duration distributions, survival curves, and interactive tables for apnea clusters and potential false negatives.

--- a/docs/user/02-visualizations.md
+++ b/docs/user/02-visualizations.md
@@ -29,6 +29,16 @@ $$
 
 where $k$ is 7 or 30 and $T_i$ is nightly usage.
 
+### Trend/Seasonal/Residual Decomposition
+
+Below the main chart a three-panel STL decomposition splits usage into:
+
+- **Trend** – A smoothed moving average showing the long-term adherence trajectory. Rising trend indicates improvement, falling trend signals creeping non-compliance.
+- **Seasonal** – Average deviation by weekday across a 7-night season. Peaks often correspond to weekend sleep-ins, while troughs reveal workday squeeze.
+- **Residual** – What remains after removing trend and seasonal components. Large spikes identify anomalous nights such as travel, illness, or equipment issues.
+
+Use the shared zoom controls to focus on specific periods; the decomposition respects the global date filter and highlights whether the story is driven by gradual change, weekly routine, or one-off outliers.
+
 ### Distribution Views
 
 - **Histogram** – Shows the frequency of usage hours; useful for spotting bimodal patterns.
@@ -42,6 +52,7 @@ Interpret flat or declining rolling curves as adherence issues. A cluster of red
 This view asks **“How severe is my apnea over time?”**
 
 - **AHI Line Chart** – Nightly AHI with 7‑/30‑night averages and change‑points. Optional stacked bars separate obstructive and central components.
+- **Trend/Seasonal/Residual Decomposition** – STL smoothing separates the weekly rhythm of AHI into a long-term trend, a repeating 7-night seasonal signature, and residual noise. The seasonal pane uncovers whether certain days of the week consistently run higher, while the residual pane isolates nights that defy both the trend and weekly pattern.
 - **Distribution Plots** – Histogram, violin, and QQ plots reveal whether AHI follows a normal distribution. Long right tails may reflect occasional bad nights.
 - **Severity Bands** – Counts how many nights fall into ranges like `0‑5`, `5‑15`, `15‑30`, `>30` AHI. Counts are computed in a single pass and memoized to avoid unnecessary recalculation. The table of “bad nights” lists dates that exceeded a chosen threshold.
 

--- a/src/components/AhiTrendsCharts.test.jsx
+++ b/src/components/AhiTrendsCharts.test.jsx
@@ -12,8 +12,11 @@ describe('AhiTrendsCharts', () => {
   it('renders plotly charts with help tooltips', () => {
     const { getAllByTestId } = render(<AhiTrendsCharts data={data} />);
     expect(getAllByTestId('plotly-chart').length).toBeGreaterThan(0);
-    // 5 charts => at least 5 help tooltips
-    expect(getAllByTestId('viz-help').length).toBeGreaterThanOrEqual(5);
+    // 6 charts => at least 6 help tooltips (including STL decomposition)
+    expect(getAllByTestId('viz-help').length).toBeGreaterThanOrEqual(6);
+    expect(
+      screen.getByText(/Trend\/Seasonal\/Residual view shows the STL decomposition/i),
+    ).toBeInTheDocument();
   });
 
   it('computes severity band counts', () => {

--- a/src/components/UsagePatternsCharts.test.jsx
+++ b/src/components/UsagePatternsCharts.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import * as UPC from './UsagePatternsCharts';
 
 const UsagePatternsCharts = UPC.default;
@@ -14,8 +14,11 @@ describe('UsagePatternsCharts', () => {
   it('renders plotly charts with help tooltips', () => {
     const { getAllByTestId } = render(<UsagePatternsCharts data={data} />);
     expect(getAllByTestId('plotly-chart').length).toBeGreaterThan(0);
-    // 4 charts => at least 4 help tooltips
-    expect(getAllByTestId('viz-help').length).toBeGreaterThanOrEqual(4);
+    // 5 charts => at least 5 help tooltips (including STL decomposition)
+    expect(getAllByTestId('viz-help').length).toBeGreaterThanOrEqual(5);
+    expect(
+      screen.getByText(/Trend\/Seasonal\/Residual view decomposes nightly usage/i),
+    ).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- add an stlDecompose helper that provides trend/seasonal/residual components and unit tests covering sine and step inputs
- extend the AHI Trends and Usage Patterns dashboards with memoized STL breakdown charts, help text, and range-selection support
- document the new decomposition panels in the README and visualization guide

## Testing
- npx vitest run src/utils/stats.test.js src/components/AhiTrendsCharts.test.jsx src/components/UsagePatternsCharts.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e2f0f8fde0832f97768b568263d621