### PR TITLE
feat: add autocorrelation diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ If `BASE_URL` is unset, the build defaults to `/oscar-export-analyzer/`.
 ## Feature Tour
 
 - **Overview Dashboard** – At‑a‑glance KPIs for adherence and AHI with small trend sparklines.
-- **Usage Patterns** – Time‑series, histograms, STL trend/seasonal/residual panes, and calendar heatmaps reveal how consistently therapy is being used. A 7‑night and 30‑night rolling average quantify medium‑ and long‑term trends while the decomposition highlights weekday habits and outlier nights.
-- **AHI Trends** – Breaks AHI into nightly values with optional obstructive/central stacking. Histogram and QQ plots test whether AHI is normally distributed, and a weekly STL decomposition separates the smooth trend from recurring seasonal swings and noisy residuals.
+- **Usage Patterns** – Time‑series, histograms, STL trend/seasonal/residual panes, calendar heatmaps, and new autocorrelation/partial autocorrelation bars reveal how consistently therapy is being used. A 7‑night and 30‑night rolling average quantify medium‑ and long‑term trends while the decomposition highlights weekday habits and outlier nights.
+- **AHI Trends** – Breaks AHI into nightly values with optional obstructive/central stacking. Histogram and QQ plots test whether AHI is normally distributed, while weekly STL decomposition and paired autocorrelation plots separate the smooth trend from recurring seasonal swings and noisy residuals.
 - **Pressure & Correlation** – Investigates how exhalation pressure (EPAP) relates to AHI. Scatter plots, LOESS curves, and correlation matrices support hypothesis generation.
 - **Range Comparison** – Select two date ranges to compute deltas, `p`‑values, and effect sizes for usage and AHI.
 - **Event Exploration** – Duration distributions, survival curves, and interactive tables for apnea clusters and potential false negatives.

--- a/docs/user/02-visualizations.md
+++ b/docs/user/02-visualizations.md
@@ -47,6 +47,10 @@ Use the shared zoom controls to focus on specific periods; the decomposition res
 
 Interpret flat or declining rolling curves as adherence issues. A cluster of red cells in the heatmap might indicate travel or equipment problems.
 
+### Autocorrelation Diagnostics
+
+Autocorrelation (ACF) and partial autocorrelation (PACF) bar charts quantify how nightly usage depends on prior nights. Bars that stay within the grey 95 % confidence band are statistically indistinguishable from white noise. Significant positive bars imply streaks of short nights or long nights tend to cluster, while significant negatives imply alternating behaviour. The PACF removes the indirect influence of intermediate nights—if it drops to near zero after lag 1 or 2, habits adjust quickly; a slow decay indicates persistent routines that may need deliberate intervention.
+
 ## AHI Trends
 
 This view asks **“How severe is my apnea over time?”**
@@ -55,6 +59,10 @@ This view asks **“How severe is my apnea over time?”**
 - **Trend/Seasonal/Residual Decomposition** – STL smoothing separates the weekly rhythm of AHI into a long-term trend, a repeating 7-night seasonal signature, and residual noise. The seasonal pane uncovers whether certain days of the week consistently run higher, while the residual pane isolates nights that defy both the trend and weekly pattern.
 - **Distribution Plots** – Histogram, violin, and QQ plots reveal whether AHI follows a normal distribution. Long right tails may reflect occasional bad nights.
 - **Severity Bands** – Counts how many nights fall into ranges like `0‑5`, `5‑15`, `15‑30`, `>30` AHI. Counts are computed in a single pass and memoized to avoid unnecessary recalculation. The table of “bad nights” lists dates that exceeded a chosen threshold.
+
+### Autocorrelation Diagnostics
+
+The ACF plot shows whether high AHI nights bunch together. Bars outside the grey 95 % band highlight lags with stronger-than-random correlation; a slowly decaying tail can indicate unresolved physiological or equipment issues that persist for several nights. The PACF chart isolates the direct dependence at each lag—sharp cutoffs suggest AHI reverts quickly once a trigger is addressed, whereas sustained PACF bars hint at longer feedback loops or uncorrected settings.
 
 Aim to keep most nights below 5. Repeated spikes or a high proportion of moderate/severe nights warrant investigation of leaks, pressure settings, or sleep hygiene.
 

--- a/src/components/AhiTrendsCharts.test.jsx
+++ b/src/components/AhiTrendsCharts.test.jsx
@@ -12,11 +12,15 @@ describe('AhiTrendsCharts', () => {
   it('renders plotly charts with help tooltips', () => {
     const { getAllByTestId } = render(<AhiTrendsCharts data={data} />);
     expect(getAllByTestId('plotly-chart').length).toBeGreaterThan(0);
-    // 6 charts => at least 6 help tooltips (including STL decomposition)
-    expect(getAllByTestId('viz-help').length).toBeGreaterThanOrEqual(6);
+    // Additional autocorrelation charts increase help tooltips count
+    expect(getAllByTestId('viz-help').length).toBeGreaterThanOrEqual(8);
     expect(
       screen.getByText(/Trend\/Seasonal\/Residual view shows the STL decomposition/i),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Autocorrelation shows how strongly tonight's AHI relates/i),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Max lag/i)).toBeInTheDocument();
   });
 
   it('computes severity band counts', () => {

--- a/src/components/UsagePatternsCharts.test.jsx
+++ b/src/components/UsagePatternsCharts.test.jsx
@@ -14,11 +14,15 @@ describe('UsagePatternsCharts', () => {
   it('renders plotly charts with help tooltips', () => {
     const { getAllByTestId } = render(<UsagePatternsCharts data={data} />);
     expect(getAllByTestId('plotly-chart').length).toBeGreaterThan(0);
-    // 5 charts => at least 5 help tooltips (including STL decomposition)
-    expect(getAllByTestId('viz-help').length).toBeGreaterThanOrEqual(5);
+    // Additional autocorrelation charts increase help tooltips count
+    expect(getAllByTestId('viz-help').length).toBeGreaterThanOrEqual(7);
     expect(
       screen.getByText(/Trend\/Seasonal\/Residual view decomposes nightly usage/i),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Autocorrelation reveals whether short nights cluster/i),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Max lag/i)).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- add reusable autocorrelation and partial autocorrelation helpers with validation tests
- render AHI and usage ACF/PACF charts with adjustable lag controls and contextual guidance
- document how to interpret autocorrelation plots in the README and user guide

## Testing
- npm test -- --run src/components/AhiTrendsCharts.test.jsx src/components/UsagePatternsCharts.test.jsx src/utils/stats.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2f5324000832fbae095c99312bb7f