### PR TITLE
Refactor app shell into providers and feature sections

### DIFF
--- a/src/App.analyticsFallback.test.jsx
+++ b/src/App.analyticsFallback.test.jsx
@@ -104,9 +104,14 @@ describe('App fallback analytics', () => {
 
     global.Worker = MockWorker;
 
-    const { default: App } = await import('./App');
+    const { default: AppShell } = await import('./App');
+    const { AppProviders } = await import('./app/AppProviders');
 
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
 
     await waitFor(() => {
       expect(analytics.finalizeClusters).toHaveBeenCalled();

--- a/src/App.analyticsWorker.test.jsx
+++ b/src/App.analyticsWorker.test.jsx
@@ -107,9 +107,14 @@ describe('App analytics worker integration', () => {
 
     global.Worker = MockWorker;
 
-    const { default: App } = await import('./App');
+    const { default: AppShell } = await import('./App');
+    const { AppProviders } = await import('./app/AppProviders');
 
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
 
     await waitFor(() => {
       expect(workerInstances.length).toBeGreaterThan(0);

--- a/src/App.csv-upload.test.jsx
+++ b/src/App.csv-upload.test.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import App from './App';
+import { AppProviders } from './app/AppProviders';
+import { AppShell } from './App';
 
 // Tests cross-component behavior triggered by CSV uploads
 
@@ -44,7 +45,11 @@ describe('CSV uploads and cross-component interactions', () => {
   });
 
   it('auto-classifies dropped files and closes the modal', async () => {
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
 
     expect(
       screen.getByRole('dialog', { name: /Import Data/i }),

--- a/src/App.header-date-filter.test.jsx
+++ b/src/App.header-date-filter.test.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
-import App from './App';
+import { AppProviders } from './app/AppProviders';
+import { AppShell } from './App';
 import ErrorBoundary from './components/ErrorBoundary';
 
 describe('Header date filter', () => {
   it('renders date inputs and presets inside the header', () => {
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
     const presetSelect = screen.getByLabelText(/quick range/i);
     const startInput = screen.getByLabelText(/start date/i);
     const endInput = screen.getByLabelText(/end date/i);
@@ -19,7 +24,11 @@ describe('Header date filter', () => {
   it('applies quick date range presets', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2023-01-10'));
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
     const presetSelect = screen.getByLabelText(/quick range/i);
     const startInput = screen.getByLabelText(/start date/i);
     const endInput = screen.getByLabelText(/end date/i);
@@ -45,7 +54,9 @@ describe('Header date filter', () => {
   it('ignores invalid dates without crashing', () => {
     render(
       <ErrorBoundary>
-        <App />
+        <AppProviders>
+          <AppShell />
+        </AppProviders>
       </ErrorBoundary>,
     );
     const startInput = screen.getByLabelText(/start date/i);

--- a/src/App.import-progress.test.jsx
+++ b/src/App.import-progress.test.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import App from './App';
+import { AppProviders } from './app/AppProviders';
+import { AppShell } from './App';
 
 describe('Header import progress', () => {
   const OriginalWorker = global.Worker;
@@ -27,7 +28,11 @@ describe('Header import progress', () => {
   });
 
   it('shows progress text and bar in the header during import', async () => {
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
     const input = screen.getByLabelText(/CSV or session files/i);
     const file = new File(['Date\n2025-06-01'], 'summary.csv', {
       type: 'text/csv',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,53 +1,56 @@
-import React, {
-  useState,
-  useEffect,
-  useMemo,
-  useCallback,
-  lazy,
-  Suspense,
-} from 'react';
-import { useCsvFiles } from './hooks/useCsvFiles';
-import { useSessionManager } from './hooks/useSessionManager';
-import {
-  FALSE_NEG_CONFIDENCE_MIN,
-  FLG_BRIDGE_THRESHOLD,
-  APOEA_CLUSTER_MIN_TOTAL_SEC,
-  MAX_CLUSTER_DURATION_SEC,
-  APNEA_GAP_DEFAULT,
-  FLG_CLUSTER_GAP_DEFAULT,
-  FLG_EDGE_ENTER_THRESHOLD_DEFAULT,
-  FLG_EDGE_EXIT_THRESHOLD_DEFAULT,
-  DEFAULT_CLUSTER_ALGORITHM,
-  DEFAULT_KMEANS_K,
-  DEFAULT_SINGLE_LINK_GAP_SEC,
-} from './utils/clustering';
-import Overview from './components/Overview';
-const SummaryAnalysis = lazy(() => import('./components/SummaryAnalysis'));
-const ApneaClusterAnalysis = lazy(
-  () => import('./components/ApneaClusterAnalysis'),
-);
-const ApneaEventStats = lazy(() => import('./components/ApneaEventStats'));
-const FalseNegativesAnalysis = lazy(
-  () => import('./components/FalseNegativesAnalysis'),
-);
-import RangeComparisons from './components/RangeComparisons';
-import RawDataExplorer from './components/RawDataExplorer';
-import ErrorBoundary from './components/ErrorBoundary';
+import React, { useEffect, useMemo } from 'react';
 import ThemeToggle from './components/ThemeToggle';
-import DocsModal from './components/DocsModal';
-import DataImportModal from './components/DataImportModal';
-import GuideLink from './components/GuideLink';
 import HeaderMenu from './components/HeaderMenu';
 import DateRangeControls from './components/DateRangeControls';
-import { buildSummaryAggregatesCSV, downloadTextFile } from './utils/export';
-import { clearLastSession } from './utils/db';
-import { DataProvider } from './context/DataContext';
-import { useAnalyticsProcessing } from './hooks/useAnalyticsProcessing';
-import { useDateRangeFilter } from './hooks/useDateRangeFilter';
-import { useGuide } from './hooks/useGuide';
-import { useModal } from './hooks/useModal';
+import DataImportModal from './components/DataImportModal';
+import DocsModal from './components/DocsModal';
+import AppLayout from './app/AppLayout';
+import { useAppContext } from './app/AppProviders';
+import OverviewSection from './features/overview/Section';
+import AnalyticsSection from './features/analytics/Section';
+import RangeComparisonsSection from './features/range-comparisons/Section';
+import ApneaClustersSection from './features/apnea-clusters/Section';
+import FalseNegativesSection from './features/false-negatives/Section';
+import RawExplorerSection from './features/raw-explorer/Section';
 
-function App() {
+export function AppShell() {
+  const {
+    loadingSummary,
+    summaryProgress,
+    summaryProgressMax,
+    loadingDetails,
+    detailsProgress,
+    detailsProgressMax,
+    processing,
+    importModal,
+    onSummaryFile,
+    onDetailsFile,
+    handleLoadSaved,
+    importSessionFile,
+    handleExportJson,
+    exportAggregatesCsv,
+    handleClearSession,
+    hasAnyData,
+    summaryAvailable,
+    error,
+    quickRange,
+    handleQuickRangeChange,
+    dateFilter,
+    setDateFilter,
+    selectCustomRange,
+    resetDateFilter,
+    parseDate,
+    formatDate,
+    activeSectionId,
+    setActiveSectionId,
+    guideOpen,
+    guideAnchor,
+    openGuideForActive,
+    closeGuide,
+    filteredSummary,
+    filteredDetails,
+  } = useAppContext();
+
   const tocSections = useMemo(
     () => [
       { id: 'overview', label: 'Overview' },
@@ -61,156 +64,7 @@ function App() {
     ],
     [],
   );
-  const [activeId, setActiveId] = useState('overview');
-  const {
-    summaryData,
-    detailsData,
-    loadingSummary,
-    summaryProgress,
-    summaryProgressMax,
-    loadingDetails,
-    detailsProgress,
-    detailsProgressMax,
-    onSummaryFile,
-    onDetailsFile,
-    setSummaryData,
-    setDetailsData,
-    error,
-  } = useCsvFiles();
-  const {
-    dateFilter,
-    setDateFilter,
-    quickRange,
-    handleQuickRangeChange,
-    parseDate,
-    formatDate,
-    selectCustomRange,
-    resetDateFilter,
-  } = useDateRangeFilter(summaryData);
-  const [rangeA, setRangeA] = useState({ start: null, end: null });
-  const [rangeB, setRangeB] = useState({ start: null, end: null });
-  const { isOpen: importOpen, open: openImportModal, close: closeImportModal } =
-    useModal(true);
-  const [clusterParams, setClusterParams] = useState({
-    algorithm: DEFAULT_CLUSTER_ALGORITHM,
-    gapSec: APNEA_GAP_DEFAULT,
-    bridgeThreshold: FLG_BRIDGE_THRESHOLD,
-    bridgeSec: FLG_CLUSTER_GAP_DEFAULT,
-    minCount: 3,
-    minTotalSec: APOEA_CLUSTER_MIN_TOTAL_SEC,
-    maxClusterSec: MAX_CLUSTER_DURATION_SEC,
-    minDensity: 0,
-    edgeEnter: FLG_EDGE_ENTER_THRESHOLD_DEFAULT,
-    edgeExit: FLG_EDGE_EXIT_THRESHOLD_DEFAULT,
-    edgeMinDurSec: 10,
-    k: DEFAULT_KMEANS_K,
-    linkageThresholdSec: DEFAULT_SINGLE_LINK_GAP_SEC,
-  });
-  const [fnPreset, setFnPreset] = useState('balanced');
-  const fnOptions = useMemo(() => {
-    const presets = {
-      strict: {
-        flThreshold: Math.max(0.9, FLG_BRIDGE_THRESHOLD),
-        confidenceMin: 0.98,
-        gapSec: FLG_CLUSTER_GAP_DEFAULT,
-        minDurationSec: 120,
-      },
-      balanced: {
-        flThreshold: FLG_BRIDGE_THRESHOLD,
-        confidenceMin: FALSE_NEG_CONFIDENCE_MIN,
-        gapSec: FLG_CLUSTER_GAP_DEFAULT,
-        minDurationSec: 60,
-      },
-      lenient: {
-        flThreshold: Math.max(0.5, FLG_BRIDGE_THRESHOLD * 0.8),
-        confidenceMin: 0.85,
-        gapSec: FLG_CLUSTER_GAP_DEFAULT,
-        minDurationSec: 45,
-      },
-    };
-    return presets[fnPreset] || presets.balanced;
-  }, [fnPreset]);
-  const { apneaClusters, falseNegatives, processing } = useAnalyticsProcessing(
-    detailsData,
-    clusterParams,
-    fnOptions,
-  );
-  const { guideOpen, guideAnchor, openGuideForActive, closeGuide } = useGuide(activeId);
-  const { handleLoadSaved, handleExportJson, importSessionFile } =
-    useSessionManager({
-      summaryData,
-      detailsData,
-      clusterParams,
-      dateFilter,
-      rangeA,
-      rangeB,
-      fnPreset,
-      setClusterParams,
-      setDateFilter,
-      setRangeA,
-      setRangeB,
-      setSummaryData,
-      setDetailsData,
-    });
 
-  const exportAggregatesCsv = useCallback(() => {
-    downloadTextFile(
-      'aggregates.csv',
-      buildSummaryAggregatesCSV(summaryData || []),
-      'text/csv',
-    );
-  }, [summaryData]);
-
-  const handleClearSession = useCallback(async () => {
-    if (
-      window.confirm(
-        'This will delete the saved session data from your browser. Continue?',
-      )
-    ) {
-      await clearLastSession();
-      setSummaryData(null);
-      setDetailsData(null);
-    }
-  }, [setSummaryData, setDetailsData]);
-
-  const hasAnyData = !!(summaryData || detailsData);
-  const summaryAvailable = !!summaryData;
-
-  const onClusterParamChange = useCallback((patch) => {
-    setClusterParams((prev) => ({ ...prev, ...patch }));
-  }, []);
-
-  const filteredSummary = useMemo(() => {
-    if (!summaryData) return null;
-    const { start, end } = dateFilter || {};
-    const dateCol = summaryData.length
-      ? Object.keys(summaryData[0]).find((c) => /date/i.test(c))
-      : null;
-    if (!dateCol || (!start && !end)) return summaryData;
-    return summaryData.filter((r) => {
-      const d = new Date(r[dateCol]);
-      if (start && d < start) return false;
-      if (end && d > end) return false;
-      return true;
-    });
-  }, [summaryData, dateFilter]);
-
-  const filteredDetails = useMemo(() => {
-    if (!detailsData) return null;
-    const { start, end } = dateFilter || {};
-    const dateCol = detailsData.length
-      ? Object.keys(detailsData[0]).find((c) => /date/i.test(c))
-      : null;
-    if (!dateCol || (!start && !end)) return detailsData;
-    return detailsData.filter((r) => {
-      const d = new Date(r[dateCol]);
-      if (start && d < start) return false;
-      if (end && d > end) return false;
-      return true;
-    });
-  }, [detailsData, dateFilter]);
-
-  // Highlight active TOC link based on visible section
   useEffect(() => {
     const root = document.documentElement;
     const cssVar = getComputedStyle(root)
@@ -222,8 +76,7 @@ function App() {
     const topMargin = headerOffset + 8;
 
     const pickActive = () => {
-      // choose the last heading whose top is above the threshold
-      const ids = tocSections.map((s) => s.id);
+      const ids = tocSections.map((section) => section.id);
       let current = ids[0];
       ids.forEach((id) => {
         const el = document.getElementById(id);
@@ -233,7 +86,7 @@ function App() {
           current = id;
         }
       });
-      setActiveId(current);
+      setActiveSectionId(current);
     };
 
     const observer = new IntersectionObserver(
@@ -242,32 +95,27 @@ function App() {
       },
       {
         root: null,
-        // Trigger when headings cross just below the sticky header and before bottom of viewport
         rootMargin: `-${topMargin}px 0px -70% 0px`,
         threshold: [0, 0.25, 0.5, 0.75, 1],
       },
     );
 
-    // Observe any headings currently in the DOM
     tocSections.forEach(({ id }) => {
       const el = document.getElementById(id);
       if (el) observer.observe(el);
     });
 
-    // Also recompute on hash change (e.g., when user clicks a link)
     const onHash = () => {
       const h = (window.location.hash || '').replace('#', '');
-      if (h) setActiveId(h);
+      if (h) setActiveSectionId(h);
     };
     window.addEventListener('hashchange', onHash);
 
-    // Update on scroll/resize to ensure responsiveness in all browsers
     const onScroll = () => pickActive();
     const onResize = () => pickActive();
     window.addEventListener('scroll', onScroll, { passive: true });
     window.addEventListener('resize', onResize);
 
-    // Initial selection
     pickActive();
 
     return () => {
@@ -276,21 +124,13 @@ function App() {
       window.removeEventListener('scroll', onScroll);
       window.removeEventListener('resize', onResize);
     };
-    // Re-run when data presence changes which may mount/unmount sections
-  }, [filteredSummary, filteredDetails, tocSections]);
+  }, [filteredSummary, filteredDetails, tocSections, setActiveSectionId]);
 
-  return (
-    <DataProvider
-      summaryData={summaryData}
-      setSummaryData={setSummaryData}
-      detailsData={detailsData}
-      setDetailsData={setDetailsData}
-      filteredSummary={filteredSummary}
-      filteredDetails={filteredDetails}
-    >
+  const beforeHeader = (
+    <>
       <DataImportModal
-        isOpen={importOpen}
-        onClose={closeImportModal}
+        isOpen={importModal.isOpen}
+        onClose={importModal.close}
         onSummaryFile={onSummaryFile}
         onDetailsFile={onDetailsFile}
         onLoadSaved={handleLoadSaved}
@@ -315,246 +155,130 @@ function App() {
           {error}
         </div>
       )}
-      <header className="app-header">
-        <div className="inner">
-          <div className="title">
-            <h1>OSCAR Sleep Data Analysis</h1>
-            <span className="badge">beta</span>
-          </div>
-          <DateRangeControls
-            quickRange={quickRange}
-            onQuickRangeChange={handleQuickRangeChange}
-            dateFilter={dateFilter}
-            onDateFilterChange={setDateFilter}
-            onCustomRange={selectCustomRange}
-            onReset={resetDateFilter}
-            parseDate={parseDate}
-            formatDate={formatDate}
-          />
-          <div className="actions">
-            <ThemeToggle />
-            <HeaderMenu
-              onOpenImport={openImportModal}
-              onExportJson={handleExportJson}
-              onExportCsv={exportAggregatesCsv}
-              onClearSession={handleClearSession}
-              onPrint={() => window.print()}
-              onOpenGuide={openGuideForActive}
-              hasAnyData={hasAnyData}
-              summaryAvailable={summaryAvailable}
-            />
-          </div>
-        </div>
-        {(loadingSummary || loadingDetails || processing) && (
-          <div className="import-progress" aria-live="polite">
-            <span>
-              {loadingSummary &&
-                `Importing summary CSV${
-                  summaryProgressMax
-                    ? ` (${Math.round(
-                        (summaryProgress / summaryProgressMax) * 100,
-                      )}%)`
-                    : ''
-                }`}
-              {loadingDetails &&
-                !loadingSummary &&
-                `Importing details CSV${
-                  detailsProgressMax
-                    ? ` (${Math.round(
-                        (detailsProgress / detailsProgressMax) * 100,
-                      )}%)`
-                    : ''
-                }`}
-              {processing &&
-                !loadingSummary &&
-                !loadingDetails &&
-                'Processing events...'}
-            </span>
-            <progress
-              value={
-                loadingSummary
-                  ? summaryProgress
-                  : loadingDetails
-                    ? detailsProgress
-                    : undefined
-              }
-              max={
-                loadingSummary
-                  ? summaryProgressMax
-                  : loadingDetails
-                    ? detailsProgressMax
-                    : undefined
-              }
-            />
-          </div>
-        )}
-      </header>
-      <div className="container">
-        <nav className="toc">
-          {tocSections.map((s) => (
-            <a
-              key={s.id}
-              href={`#${s.id}`}
-              className={activeId === s.id ? 'active' : undefined}
-              onClick={() => setActiveId(s.id)}
-            >
-              {s.label}
-            </a>
-          ))}
-        </nav>
-        {filteredSummary?.length > 0 && (
-          <div className="section">
-            <Overview
-              clusters={apneaClusters}
-              falseNegatives={falseNegatives}
-            />
-          </div>
-        )}
-        {filteredSummary?.length > 0 && (
-          <div className="section">
-            <ErrorBoundary>
-              <Suspense fallback={<div>Loading...</div>}>
-                <SummaryAnalysis clusters={apneaClusters} />
-              </Suspense>
-            </ErrorBoundary>
-            <div style={{ marginTop: 8 }}>
-              <h2 id="range-compare">
-                Range Comparisons{' '}
-                <GuideLink anchor="range-comparisons-a-vs-b" label="Guide" />
-              </h2>
-              <div
-                style={{
-                  display: 'flex',
-                  gap: 8,
-                  flexWrap: 'wrap',
-                  alignItems: 'end',
-                }}
-              >
-                <div>
-                  <label>
-                    Range A start{' '}
-                    <input
-                      type="date"
-                      onChange={(e) =>
-                        setRangeA((prev) => ({
-                          ...prev,
-                          start: e.target.value
-                            ? new Date(e.target.value)
-                            : null,
-                        }))
-                      }
-                    />
-                  </label>
-                </div>
-                <div>
-                  <label>
-                    Range A end{' '}
-                    <input
-                      type="date"
-                      onChange={(e) =>
-                        setRangeA((prev) => ({
-                          ...prev,
-                          end: e.target.value ? new Date(e.target.value) : null,
-                        }))
-                      }
-                    />
-                  </label>
-                </div>
-                <button onClick={() => setRangeA(dateFilter)}>
-                  Use current filter as A
-                </button>
-                <div style={{ width: 12 }} />
-                <div>
-                  <label>
-                    Range B start{' '}
-                    <input
-                      type="date"
-                      onChange={(e) =>
-                        setRangeB((prev) => ({
-                          ...prev,
-                          start: e.target.value
-                            ? new Date(e.target.value)
-                            : null,
-                        }))
-                      }
-                    />
-                  </label>
-                </div>
-                <div>
-                  <label>
-                    Range B end{' '}
-                    <input
-                      type="date"
-                      onChange={(e) =>
-                        setRangeB((prev) => ({
-                          ...prev,
-                          end: e.target.value ? new Date(e.target.value) : null,
-                        }))
-                      }
-                    />
-                  </label>
-                </div>
-                <button onClick={() => setRangeB(dateFilter)}>
-                  Use current filter as B
-                </button>
-              </div>
-              <ErrorBoundary>
-                <RangeComparisons rangeA={rangeA} rangeB={rangeB} />
-              </ErrorBoundary>
-            </div>
-          </div>
-        )}
-        {filteredDetails?.length > 0 && (
-          <>
-            <div className="section">
-              <ErrorBoundary>
-                <Suspense fallback={<div>Loading...</div>}>
-                  <ApneaEventStats />
-                </Suspense>
-              </ErrorBoundary>
-            </div>
-            <div className="section">
-              <ErrorBoundary>
-                <Suspense fallback={<div>Loading...</div>}>
-                  <ApneaClusterAnalysis
-                    clusters={apneaClusters}
-                    params={clusterParams}
-                    onParamChange={onClusterParamChange}
-                    details={filteredDetails}
-                  />
-                </Suspense>
-              </ErrorBoundary>
-            </div>
-            <div className="section">
-              <ErrorBoundary>
-                <Suspense fallback={<div>Loading...</div>}>
-                  <FalseNegativesAnalysis
-                    list={falseNegatives}
-                    preset={fnPreset}
-                    onPresetChange={setFnPreset}
-                  />
-                </Suspense>
-              </ErrorBoundary>
-            </div>
-            <div className="section">
-              <ErrorBoundary>
-                <RawDataExplorer
-                  onApplyDateFilter={({ start, end }) =>
-                    setDateFilter({ start, end })
-                  }
-                />
-              </ErrorBoundary>
-            </div>
-          </>
-        )}
-        <DocsModal
-          isOpen={guideOpen}
-          onClose={closeGuide}
-          initialAnchor={guideAnchor}
+    </>
+  );
+
+  const header = (
+    <div className="inner">
+      <div className="title">
+        <h1>OSCAR Sleep Data Analysis</h1>
+        <span className="badge">beta</span>
+      </div>
+      <DateRangeControls
+        quickRange={quickRange}
+        onQuickRangeChange={handleQuickRangeChange}
+        dateFilter={dateFilter}
+        onDateFilterChange={setDateFilter}
+        onCustomRange={selectCustomRange}
+        onReset={resetDateFilter}
+        parseDate={parseDate}
+        formatDate={formatDate}
+      />
+      <div className="actions">
+        <ThemeToggle />
+        <HeaderMenu
+          onOpenImport={importModal.open}
+          onExportJson={handleExportJson}
+          onExportCsv={exportAggregatesCsv}
+          onClearSession={handleClearSession}
+          onPrint={() => window.print()}
+          onOpenGuide={openGuideForActive}
+          hasAnyData={hasAnyData}
+          summaryAvailable={summaryAvailable}
         />
       </div>
-    </DataProvider>
+    </div>
+  );
+
+  const progress =
+    loadingSummary || loadingDetails || processing ? (
+      <div className="import-progress" aria-live="polite">
+        <span>
+          {loadingSummary &&
+            `Importing summary CSV${
+              summaryProgressMax
+                ? ` (${Math.round((summaryProgress / summaryProgressMax) * 100)}%)`
+                : ''
+            }`}
+          {loadingDetails &&
+            !loadingSummary &&
+            `Importing details CSV${
+              detailsProgressMax
+                ? ` (${Math.round((detailsProgress / detailsProgressMax) * 100)}%)`
+                : ''
+            }`}
+          {processing &&
+            !loadingSummary &&
+            !loadingDetails &&
+            'Processing events...'}
+        </span>
+        <progress
+          value={
+            loadingSummary
+              ? summaryProgress
+              : loadingDetails
+              ? detailsProgress
+              : undefined
+          }
+          max={
+            loadingSummary
+              ? summaryProgressMax
+              : loadingDetails
+              ? detailsProgressMax
+              : undefined
+          }
+        />
+      </div>
+    ) : null;
+
+  const toc = (
+    <>
+      {tocSections.map((section) => (
+        <a
+          key={section.id}
+          href={`#${section.id}`}
+          className={activeSectionId === section.id ? 'active' : undefined}
+          onClick={() => setActiveSectionId(section.id)}
+        >
+          {section.label}
+        </a>
+      ))}
+    </>
+  );
+
+  const summaryHasRows = !!filteredSummary?.length;
+  const detailsHasRows = !!filteredDetails?.length;
+
+  return (
+    <>
+      <AppLayout
+        beforeHeader={beforeHeader}
+        header={header}
+        progress={progress}
+        toc={toc}
+      >
+        {summaryHasRows && (
+          <>
+            <OverviewSection />
+            <AnalyticsSection />
+            <RangeComparisonsSection />
+          </>
+        )}
+        {detailsHasRows && (
+          <>
+            <ApneaClustersSection />
+            <FalseNegativesSection />
+            <RawExplorerSection />
+          </>
+        )}
+      </AppLayout>
+      <DocsModal
+        isOpen={guideOpen}
+        onClose={closeGuide}
+        initialAnchor={guideAnchor}
+      />
+    </>
   );
 }
 
-export default App;
+export default AppShell;

--- a/src/App.navigation.test.jsx
+++ b/src/App.navigation.test.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import App from './App';
+import { AppProviders } from './app/AppProviders';
+import { AppShell } from './App';
 
 describe('In-page navigation', () => {
   afterEach(() => {
@@ -10,7 +11,11 @@ describe('In-page navigation', () => {
   });
 
   it('renders Overview with only Summary CSV and updates hash on click', async () => {
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
 
     const input = await screen.findByLabelText(/CSV or session files/i);
     const summaryFile = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {

--- a/src/App.persistence.test.jsx
+++ b/src/App.persistence.test.jsx
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import App from './App.jsx';
+import { AppProviders } from './app/AppProviders.jsx';
+import { AppShell } from './App.jsx';
 
 const memoryStore = { last: null };
 
@@ -21,7 +22,11 @@ describe('App persistence flow', () => {
   });
 
   it('auto-saves after loading CSVs', async () => {
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
     const input = await screen.findByLabelText(/CSV or session files/i);
     const summaryFile = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {
       type: 'text/csv',
@@ -51,7 +56,11 @@ describe('App persistence flow', () => {
       type: 'application/json',
     });
 
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
     const input = await screen.findByLabelText(/CSV or session files/i);
     await userEvent.upload(input, file);
     const cards = await screen.findAllByText('Median AHI');
@@ -69,7 +78,11 @@ describe('App persistence flow', () => {
       detailsData: [],
     });
 
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
     const loadBtn = await screen.findByRole('button', {
       name: /Load previous session/i,
     });
@@ -80,7 +93,11 @@ describe('App persistence flow', () => {
   });
 
   it('shows an error for invalid session JSON', async () => {
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
     const input = await screen.findByLabelText(/CSV or session files/i);
     const badFile = new File(['{'], 'bad.json', { type: 'application/json' });
     await userEvent.upload(input, badFile);

--- a/src/App.print.test.jsx
+++ b/src/App.print.test.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Papa from 'papaparse';
-import App from './App';
+import { AppProviders } from './app/AppProviders';
+import { AppShell } from './App';
 
 describe('Print Page control', () => {
   afterEach(() => {
@@ -28,7 +29,11 @@ describe('Print Page control', () => {
       }
     });
 
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
 
     const input = await screen.findByLabelText(/CSV or session files/i);
     const summaryFile = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {

--- a/src/App.toc-active.test.jsx
+++ b/src/App.toc-active.test.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Papa from 'papaparse';
-import App from './App';
+import { AppProviders } from './app/AppProviders';
+import { AppShell } from './App';
 
 // Basic IntersectionObserver mock capturing instances
 class IO {
@@ -54,7 +55,11 @@ describe('TOC active highlighting', () => {
 
   it('sets active class on click and on intersection change', async () => {
     mockSummaryParse();
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
 
     const summaryFile = new File(['Date,AHI\n2025-06-01,5'], 'summary.csv', {
       type: 'text/csv',

--- a/src/App.worker.integration.test.jsx
+++ b/src/App.worker.integration.test.jsx
@@ -16,7 +16,8 @@ vi.mock('./components/UsagePatternsCharts', () => ({
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import App from './App';
+import { AppProviders } from './app/AppProviders';
+import { AppShell } from './App';
 
 describe('Worker Integration Tests', () => {
   const originalWorker = global.Worker;
@@ -26,7 +27,11 @@ describe('Worker Integration Tests', () => {
   });
 
   it('parses CSVs via worker and displays summary analysis', async () => {
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
     const summary = new File(
       ['Date,Total Time\n2025-06-01,08:00:00'],
       'summary.csv',
@@ -59,7 +64,11 @@ describe('Worker Integration Tests', () => {
     }
     global.Worker = ErrorWorker;
 
-    render(<App />);
+    render(
+      <AppProviders>
+        <AppShell />
+      </AppProviders>,
+    );
     const file = new File(['bad'], 'bad.csv', { type: 'text/csv' });
     const input = screen.getByLabelText(/CSV or session files/i);
     await userEvent.upload(input, file);

--- a/src/app/AppLayout.jsx
+++ b/src/app/AppLayout.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function AppLayout({
+  beforeHeader,
+  header,
+  progress,
+  toc,
+  children,
+}) {
+  return (
+    <>
+      {beforeHeader}
+      <header className="app-header">
+        {header}
+        {progress}
+      </header>
+      <div className="container">
+        <nav className="toc">{toc}</nav>
+        {children}
+      </div>
+    </>
+  );
+}
+
+AppLayout.propTypes = {
+  beforeHeader: PropTypes.node,
+  header: PropTypes.node,
+  progress: PropTypes.node,
+  toc: PropTypes.node,
+  children: PropTypes.node,
+};

--- a/src/app/AppProviders.jsx
+++ b/src/app/AppProviders.jsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext } from 'react';
+import PropTypes from 'prop-types';
+import { DataProvider } from '../context/DataContext';
+import { useAppState } from './useAppState';
+import { useGuide } from '../hooks/useGuide';
+
+const AppStateContext = createContext(null);
+
+export function AppProviders({ children }) {
+  const state = useAppState();
+  const guide = useGuide(state.activeSectionId);
+  const contextValue = { ...state, ...guide };
+
+  return (
+    <AppStateContext.Provider value={contextValue}>
+      <DataProvider
+        summaryData={state.summaryData}
+        setSummaryData={state.setSummaryData}
+        detailsData={state.detailsData}
+        setDetailsData={state.setDetailsData}
+        filteredSummary={state.filteredSummary}
+        filteredDetails={state.filteredDetails}
+      >
+        {children}
+      </DataProvider>
+    </AppStateContext.Provider>
+  );
+}
+
+AppProviders.propTypes = {
+  children: PropTypes.node,
+};
+
+export function useAppContext() {
+  const ctx = useContext(AppStateContext);
+  if (!ctx) {
+    throw new Error('useAppContext must be used within AppProviders');
+  }
+  return ctx;
+}

--- a/src/app/useAppState.js
+++ b/src/app/useAppState.js
@@ -1,0 +1,222 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useCsvFiles } from '../hooks/useCsvFiles';
+import { useSessionManager } from '../hooks/useSessionManager';
+import { useAnalyticsProcessing } from '../hooks/useAnalyticsProcessing';
+import { useDateRangeFilter } from '../hooks/useDateRangeFilter';
+import { useModal } from '../hooks/useModal';
+import {
+  FALSE_NEG_CONFIDENCE_MIN,
+  FLG_BRIDGE_THRESHOLD,
+  APOEA_CLUSTER_MIN_TOTAL_SEC,
+  MAX_CLUSTER_DURATION_SEC,
+  APNEA_GAP_DEFAULT,
+  FLG_CLUSTER_GAP_DEFAULT,
+  FLG_EDGE_ENTER_THRESHOLD_DEFAULT,
+  FLG_EDGE_EXIT_THRESHOLD_DEFAULT,
+  DEFAULT_CLUSTER_ALGORITHM,
+  DEFAULT_KMEANS_K,
+  DEFAULT_SINGLE_LINK_GAP_SEC,
+} from '../utils/clustering';
+import { buildSummaryAggregatesCSV, downloadTextFile } from '../utils/export';
+import { clearLastSession } from '../utils/db';
+
+export function useAppState() {
+  const csvState = useCsvFiles();
+  const {
+    summaryData,
+    setSummaryData,
+    detailsData,
+    setDetailsData,
+    loadingSummary,
+    summaryProgress,
+    summaryProgressMax,
+    loadingDetails,
+    detailsProgress,
+    detailsProgressMax,
+    onSummaryFile,
+    onDetailsFile,
+    error,
+  } = csvState;
+
+  const {
+    dateFilter,
+    setDateFilter,
+    quickRange,
+    handleQuickRangeChange,
+    parseDate,
+    formatDate,
+    selectCustomRange,
+    resetDateFilter,
+  } = useDateRangeFilter(summaryData);
+
+  const [rangeA, setRangeA] = useState({ start: null, end: null });
+  const [rangeB, setRangeB] = useState({ start: null, end: null });
+  const importModal = useModal(true);
+
+  const [clusterParams, setClusterParams] = useState({
+    algorithm: DEFAULT_CLUSTER_ALGORITHM,
+    gapSec: APNEA_GAP_DEFAULT,
+    bridgeThreshold: FLG_BRIDGE_THRESHOLD,
+    bridgeSec: FLG_CLUSTER_GAP_DEFAULT,
+    minCount: 3,
+    minTotalSec: APOEA_CLUSTER_MIN_TOTAL_SEC,
+    maxClusterSec: MAX_CLUSTER_DURATION_SEC,
+    minDensity: 0,
+    edgeEnter: FLG_EDGE_ENTER_THRESHOLD_DEFAULT,
+    edgeExit: FLG_EDGE_EXIT_THRESHOLD_DEFAULT,
+    edgeMinDurSec: 10,
+    k: DEFAULT_KMEANS_K,
+    linkageThresholdSec: DEFAULT_SINGLE_LINK_GAP_SEC,
+  });
+
+  const [fnPreset, setFnPreset] = useState('balanced');
+  const fnOptions = useMemo(() => {
+    const presets = {
+      strict: {
+        flThreshold: Math.max(0.9, FLG_BRIDGE_THRESHOLD),
+        confidenceMin: 0.98,
+        gapSec: FLG_CLUSTER_GAP_DEFAULT,
+        minDurationSec: 120,
+      },
+      balanced: {
+        flThreshold: FLG_BRIDGE_THRESHOLD,
+        confidenceMin: FALSE_NEG_CONFIDENCE_MIN,
+        gapSec: FLG_CLUSTER_GAP_DEFAULT,
+        minDurationSec: 60,
+      },
+      lenient: {
+        flThreshold: Math.max(0.5, FLG_BRIDGE_THRESHOLD * 0.8),
+        confidenceMin: 0.85,
+        gapSec: FLG_CLUSTER_GAP_DEFAULT,
+        minDurationSec: 45,
+      },
+    };
+    return presets[fnPreset] || presets.balanced;
+  }, [fnPreset]);
+
+  const analytics = useAnalyticsProcessing(detailsData, clusterParams, fnOptions);
+  const { apneaClusters, falseNegatives, processing } = analytics;
+
+  const session = useSessionManager({
+    summaryData,
+    detailsData,
+    clusterParams,
+    dateFilter,
+    rangeA,
+    rangeB,
+    fnPreset,
+    setClusterParams,
+    setDateFilter,
+    setRangeA,
+    setRangeB,
+    setSummaryData,
+    setDetailsData,
+  });
+
+  const exportAggregatesCsv = useCallback(() => {
+    downloadTextFile(
+      'aggregates.csv',
+      buildSummaryAggregatesCSV(summaryData || []),
+      'text/csv',
+    );
+  }, [summaryData]);
+
+  const handleClearSession = useCallback(async () => {
+    if (
+      window.confirm(
+        'This will delete the saved session data from your browser. Continue?',
+      )
+    ) {
+      await clearLastSession();
+      setSummaryData(null);
+      setDetailsData(null);
+    }
+  }, [setDetailsData, setSummaryData]);
+
+  const hasAnyData = !!(summaryData || detailsData);
+  const summaryAvailable = !!summaryData;
+
+  const onClusterParamChange = useCallback((patch) => {
+    setClusterParams((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const filteredSummary = useMemo(() => {
+    if (!summaryData) return null;
+    const { start, end } = dateFilter || {};
+    const dateCol = summaryData.length
+      ? Object.keys(summaryData[0]).find((c) => /date/i.test(c))
+      : null;
+    if (!dateCol || (!start && !end)) return summaryData;
+    return summaryData.filter((row) => {
+      const d = new Date(row[dateCol]);
+      if (start && d < start) return false;
+      if (end && d > end) return false;
+      return true;
+    });
+  }, [summaryData, dateFilter]);
+
+  const filteredDetails = useMemo(() => {
+    if (!detailsData) return null;
+    const { start, end } = dateFilter || {};
+    const dateCol = detailsData.length
+      ? Object.keys(detailsData[0]).find((c) => /date/i.test(c))
+      : null;
+    if (!dateCol || (!start && !end)) return detailsData;
+    return detailsData.filter((row) => {
+      const d = new Date(row[dateCol]);
+      if (start && d < start) return false;
+      if (end && d > end) return false;
+      return true;
+    });
+  }, [detailsData, dateFilter]);
+
+  const [activeSectionId, setActiveSectionId] = useState('overview');
+
+  return {
+    summaryData,
+    setSummaryData,
+    detailsData,
+    setDetailsData,
+    loadingSummary,
+    summaryProgress,
+    summaryProgressMax,
+    loadingDetails,
+    detailsProgress,
+    detailsProgressMax,
+    onSummaryFile,
+    onDetailsFile,
+    error,
+    dateFilter,
+    setDateFilter,
+    quickRange,
+    handleQuickRangeChange,
+    parseDate,
+    formatDate,
+    selectCustomRange,
+    resetDateFilter,
+    rangeA,
+    setRangeA,
+    rangeB,
+    setRangeB,
+    importModal,
+    clusterParams,
+    setClusterParams,
+    fnPreset,
+    setFnPreset,
+    apneaClusters,
+    falseNegatives,
+    processing,
+    handleLoadSaved: session.handleLoadSaved,
+    handleExportJson: session.handleExportJson,
+    importSessionFile: session.importSessionFile,
+    exportAggregatesCsv,
+    handleClearSession,
+    hasAnyData,
+    summaryAvailable,
+    onClusterParamChange,
+    filteredSummary,
+    filteredDetails,
+    activeSectionId,
+    setActiveSectionId,
+  };
+}

--- a/src/features/analytics/Section.jsx
+++ b/src/features/analytics/Section.jsx
@@ -1,0 +1,23 @@
+import React, { Suspense, lazy } from 'react';
+import ErrorBoundary from '../../components/ErrorBoundary';
+import { useAppContext } from '../../app/AppProviders';
+
+const SummaryAnalysis = lazy(() => import('../../components/SummaryAnalysis'));
+
+export default function AnalyticsSection() {
+  const { filteredSummary, apneaClusters } = useAppContext();
+
+  if (!filteredSummary?.length) {
+    return null;
+  }
+
+  return (
+    <div className="section">
+      <ErrorBoundary>
+        <Suspense fallback={<div>Loading...</div>}>
+          <SummaryAnalysis clusters={apneaClusters} />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/src/features/apnea-clusters/Section.jsx
+++ b/src/features/apnea-clusters/Section.jsx
@@ -1,0 +1,39 @@
+import React, { Suspense, lazy } from 'react';
+import ErrorBoundary from '../../components/ErrorBoundary';
+import { useAppContext } from '../../app/AppProviders';
+
+const ApneaEventStats = lazy(() => import('../../components/ApneaEventStats'));
+const ApneaClusterAnalysis = lazy(() => import('../../components/ApneaClusterAnalysis'));
+
+export default function ApneaClustersSection() {
+  const { filteredDetails, apneaClusters, clusterParams, onClusterParamChange } =
+    useAppContext();
+
+  if (!filteredDetails?.length) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="section">
+        <ErrorBoundary>
+          <Suspense fallback={<div>Loading...</div>}>
+            <ApneaEventStats />
+          </Suspense>
+        </ErrorBoundary>
+      </div>
+      <div className="section">
+        <ErrorBoundary>
+          <Suspense fallback={<div>Loading...</div>}>
+            <ApneaClusterAnalysis
+              clusters={apneaClusters}
+              params={clusterParams}
+              onParamChange={onClusterParamChange}
+              details={filteredDetails}
+            />
+          </Suspense>
+        </ErrorBoundary>
+      </div>
+    </>
+  );
+}

--- a/src/features/false-negatives/Section.jsx
+++ b/src/features/false-negatives/Section.jsx
@@ -1,0 +1,30 @@
+import React, { Suspense, lazy } from 'react';
+import ErrorBoundary from '../../components/ErrorBoundary';
+import { useAppContext } from '../../app/AppProviders';
+
+const FalseNegativesAnalysis = lazy(() =>
+  import('../../components/FalseNegativesAnalysis'),
+);
+
+export default function FalseNegativesSection() {
+  const { filteredDetails, falseNegatives, fnPreset, setFnPreset } =
+    useAppContext();
+
+  if (!filteredDetails?.length) {
+    return null;
+  }
+
+  return (
+    <div className="section">
+      <ErrorBoundary>
+        <Suspense fallback={<div>Loading...</div>}>
+          <FalseNegativesAnalysis
+            list={falseNegatives}
+            preset={fnPreset}
+            onPresetChange={setFnPreset}
+          />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/src/features/overview/Section.jsx
+++ b/src/features/overview/Section.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Overview from '../../components/Overview';
+import { useAppContext } from '../../app/AppProviders';
+
+export default function OverviewSection() {
+  const { filteredSummary, apneaClusters, falseNegatives } = useAppContext();
+
+  if (!filteredSummary?.length) {
+    return null;
+  }
+
+  return (
+    <div className="section">
+      <Overview clusters={apneaClusters} falseNegatives={falseNegatives} />
+    </div>
+  );
+}

--- a/src/features/range-comparisons/Section.jsx
+++ b/src/features/range-comparisons/Section.jsx
@@ -1,0 +1,91 @@
+import React, { useCallback } from 'react';
+import ErrorBoundary from '../../components/ErrorBoundary';
+import RangeComparisons from '../../components/RangeComparisons';
+import GuideLink from '../../components/GuideLink';
+import { useAppContext } from '../../app/AppProviders';
+
+export default function RangeComparisonsSection() {
+  const { filteredSummary, rangeA, setRangeA, rangeB, setRangeB, dateFilter } =
+    useAppContext();
+
+  const hasSummary = !!filteredSummary?.length;
+
+  const handleRangeChange = useCallback(
+    (setter, key) => (event) => {
+      const { value } = event.target;
+      setter((prev) => ({
+        ...prev,
+        [key]: value ? new Date(value) : null,
+      }));
+    },
+    [],
+  );
+
+  const useCurrentFilter = useCallback(
+    (setter) => {
+      setter(dateFilter ? { ...dateFilter } : { start: null, end: null });
+    },
+    [dateFilter],
+  );
+
+  if (!hasSummary) {
+    return null;
+  }
+
+  return (
+    <div className="section">
+      <h2 id="range-compare">
+        Range Comparisons <GuideLink anchor="range-comparisons-a-vs-b" label="Guide" />
+      </h2>
+      <div
+        style={{
+          display: 'flex',
+          gap: 8,
+          flexWrap: 'wrap',
+          alignItems: 'end',
+        }}
+      >
+        <div>
+          <label>
+            Range A start{' '}
+            <input
+              type="date"
+              onChange={handleRangeChange(setRangeA, 'start')}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Range A end{' '}
+            <input type="date" onChange={handleRangeChange(setRangeA, 'end')} />
+          </label>
+        </div>
+        <button onClick={() => useCurrentFilter(setRangeA)}>
+          Use current filter as A
+        </button>
+        <div style={{ width: 12 }} />
+        <div>
+          <label>
+            Range B start{' '}
+            <input
+              type="date"
+              onChange={handleRangeChange(setRangeB, 'start')}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Range B end{' '}
+            <input type="date" onChange={handleRangeChange(setRangeB, 'end')} />
+          </label>
+        </div>
+        <button onClick={() => useCurrentFilter(setRangeB)}>
+          Use current filter as B
+        </button>
+      </div>
+      <ErrorBoundary>
+        <RangeComparisons rangeA={rangeA} rangeB={rangeB} />
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/src/features/raw-explorer/Section.jsx
+++ b/src/features/raw-explorer/Section.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import ErrorBoundary from '../../components/ErrorBoundary';
+import RawDataExplorer from '../../components/RawDataExplorer';
+import { useAppContext } from '../../app/AppProviders';
+
+export default function RawExplorerSection() {
+  const { filteredDetails, setDateFilter } = useAppContext();
+
+  if (!filteredDetails?.length) {
+    return null;
+  }
+
+  return (
+    <div className="section">
+      <ErrorBoundary>
+        <RawDataExplorer
+          onApplyDateFilter={({ start, end }) => setDateFilter({ start, end })}
+        />
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App.jsx';
 import ErrorBoundary from './components/ErrorBoundary.jsx';
+import { AppProviders } from './app/AppProviders.jsx';
+import { AppShell } from './App.jsx';
 
 import '../styles.css';
 import './guide.css';
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
     <ErrorBoundary>
-      <App />
+      <AppProviders>
+        <AppShell />
+      </AppProviders>
     </ErrorBoundary>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add AppProviders and useAppState to centralize CSV, analytics, and modal state for the app
- refactor AppShell to use a lightweight AppLayout and compose feature sections from src/features
- extract overview, analytics, range comparison, cluster, false negative, and raw explorer sections into feature modules and refresh the architecture docs and tests

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e619509744832f8fd1b53b65311c57